### PR TITLE
bump version of td-agent-bit to 0.9.0

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -68,7 +68,7 @@ TD_AGENT_VERSIONS = {
     mac: "2.3.0"
   },
   :bit => {
-    linux: "0.8.5"
+    linux: "0.9.0"
   }
 }
 

--- a/views/download.erb
+++ b/views/download.erb
@@ -173,7 +173,7 @@
               <span style="font-style:bold;">TD-Agent Bit v<%=TD_AGENT_VERSIONS[:bit][:linux]%></span>
               <ul>
                 <li>
-                  <a href="http://fluentbit.io/documentation/0.8/installation/redhat_centos.html">Download Instructions</a>
+                  <a href="http://fluentbit.io/documentation/0.9/installation/redhat_centos.html">Download Instructions</a>
                 </li>
               </ul>
             </td>
@@ -193,7 +193,7 @@
               <span style="font-style:bold;">TD-Agent Bit v<%=TD_AGENT_VERSIONS[:bit][:linux]%></span>
               <ul>
                 <li>
-                  <a href="http://fluentbit.io/documentation/0.8/installation/ubuntu.html">Download Instructions</a>
+                  <a href="http://fluentbit.io/documentation/0.9/installation/ubuntu.html">Download Instructions</a>
                 </li>
               </ul>
             </td>


### PR DESCRIPTION
Now, we can get a td-agent-bit v0.9.
(e.g td-agent-bit-0.9.0-1.x86_64, via yum)

So, I bumped 0.8.5 -> 0.9.0.