### PR TITLE
Add fluent-plugin-mysqlslowquery to obsolete plugins

### DIFF
--- a/scripts/plugins.rb
+++ b/scripts/plugins.rb
@@ -71,7 +71,8 @@ class Plugins
     'fluent-plugin-tail-asis',
     'fluent-plugin-hostname',
     'fluent-plugin-mysql-bulk',
-    'fluent-plugin-calc'
+    'fluent-plugin-calc',
+    'fluent-plugin-mysqlslowquery'
   ]
 end
 


### PR DESCRIPTION
Because it has been maintained since 2015-10-08 or earlier.
See https://github.com/yuku-t/fluent-plugin-mysqlslowquery/issues/15#issuecomment-146473679