### PR TITLE
Add fluent-plugin-tail_path to obsoleted plugins

### DIFF
--- a/scripts/plugins.rb
+++ b/scripts/plugins.rb
@@ -72,7 +72,8 @@ class Plugins
     'fluent-plugin-hostname',
     'fluent-plugin-mysql-bulk',
     'fluent-plugin-calc',
-    'fluent-plugin-mysqlslowquery'
+    'fluent-plugin-mysqlslowquery',
+    'fluent-plugin-tail_path',
   ]
 end
 


### PR DESCRIPTION
Because in_tail_path had been merged in in_tail in v0.12.

ref: https://github.com/fluent/fluentd/issues/945
ref: https://github.com/fluent/fluentd/pull/951

~~Please merge this PR after Fluentd reaches v0.14.x as stable.~~
I've confirmed that in_tail_path is also merged into v0.12.