### PR TITLE
Add fluent-plugin-amqp2 to obsolete plugins

### DIFF
--- a/scripts/plugins.rb
+++ b/scripts/plugins.rb
@@ -74,6 +74,7 @@ class Plugins
     'fluent-plugin-calc',
     'fluent-plugin-mysqlslowquery',
     'fluent-plugin-tail_path',
+    'fluent-plugin-amqp2',
   ]
 end
 


### PR DESCRIPTION
* It has not been maintained since 2 years ago
* fluent-plugin-amqp has been maintained actively
  * It has both output plugin and input pluguin
  * Support v0.14 API