### PR TITLE
Update obsolete plugins

### DIFF
--- a/scripts/obsolete-plugins.yml
+++ b/scripts/obsolete-plugins.yml
@@ -41,3 +41,7 @@ fluent-plugin-kinesis-alt: |+
   Unmaintained since 2013-12-26. Use [fluent-plugin-kinesis](https://github.com/awslabs/aws-fluent-plugin-kinesis) instead.
 fluent-plugin-cloudtrail: |+
   Deprecated: Consider using [fluent-plugin-s3](https://github.com/fluent/fluent-plugin-s3).
+fluent-plugin-bigquery-custom: |+
+  Almost feature is included in original. Use fluent-plugin-bigquery instead.
+fluent-plugin-embedded-elasticsearch: |+
+  Git repository has gone away.


### PR DESCRIPTION
* fluent-plugin-bigquery-custom

Owner said: Almost feature is included in original. Use
fluent-plugin-bigquery instead.

* fluent-plugin-embedded-elasticsearch

Git repository has gone away.