### PR TITLE
Mark obsolete fluent-plugin-kestrel

### DIFF
--- a/scripts/obsolete-plugins.yml
+++ b/scripts/obsolete-plugins.yml
@@ -45,3 +45,5 @@ fluent-plugin-bigquery-custom: |+
   Almost feature is included in original. Use fluent-plugin-bigquery instead.
 fluent-plugin-embedded-elasticsearch: |+
   Git repository has gone away.
+fluent-plugin-kestrel: |+
+  [Kestrel](https://github.com/robey/kestrel) is inactive. Unmaintained since 2014-03-07.


### PR DESCRIPTION
Because [Kestrel](https://github.com/robey/kestrel) is inactive and
unmaintained since 2014-03-07.