### PR TITLE
Mark fluent-plugin-droonga obsolete

### DIFF
--- a/scripts/obsolete-plugins.yml
+++ b/scripts/obsolete-plugins.yml
@@ -57,3 +57,5 @@ fluent-plugin-encrypt: |+
   This is outdated. See [comment](https://github.com/tagomoris/fluent-plugin-encrypt/pull/4#issuecomment-299804521).
 fluent-plugin-winevtlog: |+
   Use [fluent-plugin-windows-eventlog](https://github.com/fluent/fluent-plugin-windows-eventlog) instead.
+fluent-plugin-droonga: |+
+  Use [Droonga engine](https://github.com/droonga/droonga-engine) instead.


### PR DESCRIPTION
Because it has been replaced with Droonga engine.