### PR TITLE
Mark fluent-plugin-growl is obsolete

### DIFF
--- a/scripts/obsolete-plugins.yml
+++ b/scripts/obsolete-plugins.yml
@@ -59,3 +59,5 @@ fluent-plugin-winevtlog: |+
   Use [fluent-plugin-windows-eventlog](https://github.com/fluent/fluent-plugin-windows-eventlog) instead.
 fluent-plugin-droonga: |+
   Use [Droonga engine](https://github.com/droonga/droonga-engine) instead.
+fluent-plugin-growl: |+
+  Growl does not support OS X 10.10 or later. Use [fluent-plugin-terminal_notifier](https://github.com/cosmo0920/fluent-plugin-terminal_notifier) instead.


### PR DESCRIPTION
Because Growl does not support OS X 10.10 or later.
And 10.10 encourages to use notification center.