### PR TITLE
Mark fluent-plugin-ynamodb-drc as obsoleted

### DIFF
--- a/scripts/obsolete-plugins.yml
+++ b/scripts/obsolete-plugins.yml
@@ -67,3 +67,5 @@ fluent-plugin-norikra-patched-7: |+
   Already merged into upstream.
 fluent-plugin-boundio: |+
   Boundio has closed on the 30th Sep 2013. Use [fluent-plugin-twilio](https://github.com/y-ken/fluent-plugin-twilio) instead.
+fluent-plugin-dynamodb-drc: |+
+  Unmaintained since 2014-09-30. Use [fluent-plugin-dynamodb](https://github.com/gonsuke/fluent-plugin-dynamodb) instead.


### PR DESCRIPTION
Obsoleted Reasons:

* Depends on Fluentd v0.10
  * It causes installation error when users use Ruby 2.4
* Unmaintained since 30 Sep 2014
  * I sometimes send ping, but no response from maintainer
* fluent-plugin-dynamodb has almost same functionality