### PR TITLE
Mark fluent-plugin-kafka-enchanced as obsoleted

### DIFF
--- a/scripts/obsolete-plugins.yml
+++ b/scripts/obsolete-plugins.yml
@@ -79,3 +79,5 @@ fluent-plugin-gcloud-storage: |+
 fluent-plugin-redshift-aws-v1: |+
   Using aws-sdk-v1 is alreay supported at upstream.
   Use [fluent-plugin-redshift](https://github.com/flydata/fluent-plugin-redshift) instead.
+fluent-plugin-kafka-enchanced: |+
+  Git repository has gone away.


### PR DESCRIPTION
* fluent-plugin-kafka-enchanced repository has gone away