### PR TITLE
Mark fluent-plugin-redshift-kwarter and fluent-plugin-hekk_redshift as obsoleted plugin

### DIFF
--- a/scripts/obsolete-plugins.yml
+++ b/scripts/obsolete-plugins.yml
@@ -79,3 +79,7 @@ fluent-plugin-gcloud-storage: |+
 fluent-plugin-redshift-aws-v1: |+
   Using aws-sdk-v1 is alreay supported at upstream.
   Use [fluent-plugin-redshift](https://github.com/flydata/fluent-plugin-redshift) instead.
+fluent-plugin-redshift-kwarter: |+
+  Almost feature is included in original. Use [fluent-plugin-redshift](https://github.com/flydata/fluent-plugin-redshift) instead.
+fluent-plugin-hekk_redshift: |+
+  Almost feature is included in original. Use [fluent-plugin-redshift](https://github.com/flydata/fluent-plugin-redshift) instead.


### PR DESCRIPTION
* These plugins are modified gem name only, but almost feature is included in original.