### PR TITLE
Mark fluent-plugin-elasticsearch-ssl-verify as obsoleted

### DIFF
--- a/scripts/obsolete-plugins.yml
+++ b/scripts/obsolete-plugins.yml
@@ -83,3 +83,5 @@ fluent-plugin-redshift-kwarter: |+
   Almost feature is included in original. Use [fluent-plugin-redshift](https://github.com/flydata/fluent-plugin-redshift) instead.
 fluent-plugin-hekk_redshift: |+
   Almost feature is included in original. Use [fluent-plugin-redshift](https://github.com/flydata/fluent-plugin-redshift) instead.
+fluent-plugin-elasticsearch-ssl-verify: |+
+  SSL verify feature is included in original. Use [fluent-plugin-elasticsearch](https://github.com/uken/fluent-plugin-elasticsearch) instead.


### PR DESCRIPTION
Because SSL verify feature is included in original.