### PR TITLE
Add slack for Notification plugin category

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -287,7 +287,7 @@ get '/plugins' do
     "Google Cloud Platform" => 'google bigquery',
     "Internet of Things" => 'mqtt',
     "Monitoring" => "growthforecast graphite monitor librato zabbix",
-    "Notifications" => "irc ikachan hipchat twilio",
+    "Notifications" => "slack irc ikachan hipchat twilio",
     "NoSQL" => 'riak couch mongo couchbase rethink influxdb',
     "Online Processing" => 'norikra anomaly',
     "RDBMS" => 'mysql postgres vertica',


### PR DESCRIPTION
How about adding slack entry for plugin page?
https://www.fluentd.org/plugins#notifications

Because Slack plugin is most downloaded major notification plugin.
![image](https://user-images.githubusercontent.com/1734549/31487339-42e45318-af75-11e7-870c-bc068b514b15.png)

And I confirmed that also have a entry of slack in `scripts/plugins.json`
