### PR TITLE
Mark fluent-plugin-grep as deprecated

### DIFF
--- a/scripts/obsolete-plugins.yml
+++ b/scripts/obsolete-plugins.yml
@@ -85,3 +85,6 @@ fluent-plugin-hekk_redshift: |+
   Almost feature is included in original. Use [fluent-plugin-redshift](https://github.com/flydata/fluent-plugin-redshift) instead.
 fluent-plugin-elasticsearch-ssl-verify: |+
   SSL verify feature is included in original. Use [fluent-plugin-elasticsearch](https://github.com/uken/fluent-plugin-elasticsearch) instead.
+fluent-plugin-grep: |+
+  [grep filter](http://docs.fluentd.org/articles/filter_grep) is now a built-in plugin. Use the built-in plugin instead of installing this plugin.
+  Or, [fluent-plugin-filter_where](https://github.com/sonots/fluent-plugin-filter_where) is more useful.


### PR DESCRIPTION
> NOTE: grep filter is now a built-in plugin. Use the built-in plugin instead of installing this plugin.

> Or, you may find https://github.com/sonots/fluent-plugin-filter_where is more useful.

see: https://github.com/sonots/fluent-plugin-grep