### PR TITLE
Some parser plugins are replaced with built-in plugin

### DIFF
--- a/scripts/obsolete-plugins.yml
+++ b/scripts/obsolete-plugins.yml
@@ -88,3 +88,10 @@ fluent-plugin-elasticsearch-ssl-verify: |+
 fluent-plugin-grep: |+
   [grep filter](http://docs.fluentd.org/articles/filter_grep) is now a built-in plugin. Use the built-in plugin instead of installing this plugin.
   Or, [fluent-plugin-filter_where](https://github.com/sonots/fluent-plugin-filter_where) is more useful.
+fluent-plugin-kv-parser: |+
+  Use built-in [parser_ltsv](https://docs.fluentd.org/v1.0/articles/parser_ltsv) instead of installing this plugin.
+  Built-in parser_ltsv provides all feature of this plugin.
+fluent-plugin-ltsv-parser: |+
+  Use built-in [parser_ltsv](https://docs.fluentd.org/v1.0/articles/parser_ltsv) instead of installing this plugin to parse LTSV.
+fluent-plugin-json-parser: |+
+  Use built-in [parser_json](https://docs.fluentd.org/v1.0/articles/parser_json) instead of installing this plugin to parse JSON.


### PR DESCRIPTION
fluent-plugin-kv-parser is replaced with built-in parser_ltsv, because
parser_ltsv provides all feature of fluent-plugin-kv-parser.

fluent-plugin-lvsv-parser is replaced with build-in parser_ltsv,
because fluent-plugin-ltsv-parser has benn unmaintained since
2014-10-29, and built-in parser_ltsv provides the feature to parse LTSV.

fluent-plugin-json-parser is replaced with built-in parser_json,
because fluent-plugin-json-parser has benn unmaintained since
2014-08-19, and built-in parser_json provides the feature to parse JSON.