### PR TITLE
Mark fluent-plugin-kanicounter as obsoleted

### DIFF
--- a/scripts/obsolete-plugins.yml
+++ b/scripts/obsolete-plugins.yml
@@ -99,3 +99,5 @@ fluent-plugin-ltsv-parser: |+
   Use built-in [parser_ltsv](https://docs.fluentd.org/v1.0/articles/parser_ltsv) instead of installing this plugin to parse LTSV.
 fluent-plugin-json-parser: |+
   Use built-in [parser_json](https://docs.fluentd.org/v1.0/articles/parser_json) instead of installing this plugin to parse JSON.
+fluent-plugin-kanicounter: |+
+  This plugin does not include any practical functionalities.


### PR DESCRIPTION
fluent-plugin-kanicounter doesn't include any practical functionalities.