### PR TITLE
Mark fluent-plugin-stdout and fluent-plugin-buffered-hipchat obsoleted

### DIFF
--- a/scripts/obsolete-plugins.yml
+++ b/scripts/obsolete-plugins.yml
@@ -101,3 +101,6 @@ fluent-plugin-json-parser: |+
   Use built-in [parser_json](https://docs.fluentd.org/v1.0/articles/parser_json) instead of installing this plugin to parse JSON.
 fluent-plugin-kanicounter: |+
   This plugin does not include any practical functionalities.
+fluent-plugin-buffered-stdout: |+
+  Use built-in [out_stdout](https://docs.fluentd.org/v1.0/articles/out_stdout) instead of installing this plugin to print events to stdout.
+

--- a/scripts/obsolete-plugins.yml
+++ b/scripts/obsolete-plugins.yml
@@ -103,4 +103,5 @@ fluent-plugin-kanicounter: |+
   This plugin does not include any practical functionalities.
 fluent-plugin-buffered-stdout: |+
   Use built-in [out_stdout](https://docs.fluentd.org/v1.0/articles/out_stdout) instead of installing this plugin to print events to stdout.
-
+fluent-plugin-buffered-hipchat: |+
+  Use [fluent-plugin-hipchat](https://github.com/fluent-plugins-nursery/fluent-plugin-hipchat), it provides buffering functionality.


### PR DESCRIPTION
built-in stdout can buffer events.
fluent-plugin-hipchat can also buffer events.