### PR TITLE
Stop storing duplicated gems

### DIFF
--- a/scripts/plugins.rb
+++ b/scripts/plugins.rb
@@ -34,7 +34,7 @@ class Plugins
       exit ecode
     end
 
-    gemlist = cmdout.scan(/fluent-plugin-[^\s]+/)
+    gemlist = cmdout.scan(/^fluent-plugin-[^\s]+/)
     plugins = []
     http = Net::HTTP.new("rubygems.org", 443)
     http.use_ssl = true


### PR DESCRIPTION
`gem search -r fluent-plugin` includes following gems:

* ivelum-fluent-plugin-oomkiller
* roched-fluent-plugin-kafka
* sm-fluent-plugin-sql
* vmik-fluent-plugin-google-cloud

`cmdout.scan(/fluent-plugin-[^\s]+/)` will return followings:

* fluent-plugin-oomkiller
* fluent-plugin-kafka
* fluent-plugin-sql
* fluent-plugin-google-cloud

So we see duplicated entries in https://www.fluentd.org/plugins/all

This change omit username-prefixed gems on the above.