### PR TITLE
Mark fluent-plugin-filter-geo as obsoleted

### DIFF
--- a/scripts/obsolete-plugins.yml
+++ b/scripts/obsolete-plugins.yml
@@ -107,3 +107,5 @@ fluent-plugin-buffered-hipchat: |+
   Use [fluent-plugin-hipchat](https://github.com/fluent-plugins-nursery/fluent-plugin-hipchat), it provides buffering functionality.
 fluent-plugin-logfmt-parser: |+
   Git repository has gone away.
+fluent-plugin-filter-geo: |+
+  Git repository has gone away.


### PR DESCRIPTION
Because its repository has gone away.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>