### PR TITLE
Add download links for Ubuntu 18.04 (Bionic Beaver)

### DIFF
--- a/views/download.erb
+++ b/views/download.erb
@@ -62,7 +62,8 @@
               <ul>
                 <li><a href="//docs.fluentd.org/v1.0/articles/install-by-deb">Installation Guide</a></li>
                 <li>
-                  64-bit/amd64 (<a href="https://td-agent-package-browser.herokuapp.com/3/ubuntu/xenial/pool/contrib/t/td-agent">Xenial</a>,
+                  64-bit/amd64 (<a href="https://td-agent-package-browser.herokuapp.com/3/ubuntu/bionic/pool/contrib/t/td-agent">Bionic</a>,
+                  <a href="https://td-agent-package-browser.herokuapp.com/3/ubuntu/xenial/pool/contrib/t/td-agent">Xenial</a>,
                   <a href="https://td-agent-package-browser.herokuapp.com/3/ubuntu/trusty/pool/contrib/t/td-agent">Trusty</a>)
                   <a href="https://td-agent-package-browser.herokuapp.com/3/debian/stretch/pool/contrib/t/td-agent">Stretch</a>,
                   <a href="https://td-agent-package-browser.herokuapp.com/3/debian/jessie/pool/contrib/t/td-agent">Jessie</a>


### PR DESCRIPTION
While updating the Graylog article in https://github.com/fluent/fluentd-docs/pull/587, I noticed
that the download link for the latest Ubuntu version was missing. 

This patch contains a trivial fix for the issue.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>