### PR TITLE
Show the correct icon for OpenTSDB

### DIFF
--- a/views/dataoutputs.erb
+++ b/views/dataoutputs.erb
@@ -222,7 +222,7 @@
                ['Couchbase', 'couchbase.png', 'https://github.com/obieq/fluent-plugin-couchbase'],
                ['Riak', 'riak.png', 'http://basho.com/fluentd-loves-riak/'],
                ['HBase', 'hbase.png', 'https://github.com/Furyu/fluent-plugin-hbase'],
-               ['OpenTSDB', 'hbase.png', 'https://github.com/emurphy/fluent-plugin-opentsdb'],
+               ['OpenTSDB', 'opentsdb.png', 'https://github.com/emurphy/fluent-plugin-opentsdb'],
                ['ZeroMQ', 'zeromq.png', 'https://github.com/ogibayashi/fluent-plugin-zmq-pub'],
              ].each_slice(7) do |a|
           %>


### PR DESCRIPTION
The "List of Outputs" page shows wrong logo icon for OpenTSDB
(displaying the one for HBase). 

This patch resolves the issue and should fix #72 

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>