### PR TITLE
Mark fluent-plugin-out-http-ext as obsoleted

### DIFF
--- a/scripts/obsolete-plugins.yml
+++ b/scripts/obsolete-plugins.yml
@@ -111,3 +111,5 @@ fluent-plugin-filter-geo: |+
   Git repository has gone away.
 fluent-plugin-logzio-ng: |+
   Git repository has gone away.
+fluent-plugin-out-http-ext: |+
+  Use [fluent-plugin-out-http](https://github.com/fluent-plugins-nursery/fluent-plugin-out-http), it implements downstream plugin functionality.


### PR DESCRIPTION
Upstream plugin, which is fluent-plugin-out-http, supports full downstream plugin functionality. It can be replaceable now.