### PR TITLE
blog: fix the title of the v1.4.2 release note

### DIFF
--- a/content/blog/20190402_fluentd-v1.4.2-has-been-released.md
+++ b/content/blog/20190402_fluentd-v1.4.2-has-been-released.md
@@ -1,4 +1,4 @@
-# Fluentd v1.4.1 has been released
+# Fluentd v1.4.2 has been released
 
 Hi users!
 


### PR DESCRIPTION
This is the release note for `v1.4.2`.
Update the article title so that it references the correct version number.