### PR TITLE
Fixing Installation Guide links on download page

### DIFF
--- a/views/download.erb
+++ b/views/download.erb
@@ -41,7 +41,7 @@
             <td>
               <span style="font-style:bold">td-agent v<%=TD_AGENT_VERSIONS[:v3][:linux]%></span>
               <ul>
-                <li><a href="http://docs.fluentd.org/v1.0/articles/install-by-rpm">Installation Guide</a></li>
+                <li><a href="//docs.fluentd.org/v1.0/articles/install-by-rpm">Installation Guide</a></li>
                 <li>
                   64-bit (<a href="https://td-agent-package-browser.herokuapp.com/3/redhat/7/x86_64">RHEL7</a>,
                   <a href="https://td-agent-package-browser.herokuapp.com/3/redhat/6/x86_64">RHEL6</a>)
@@ -102,7 +102,7 @@
             <td>
               <span style="font-style:bold">td-agent v<%=TD_AGENT_VERSIONS[:v3][:mac]%></span>
               <ul>
-                <li><a href="//docs.fluentd.org/articles/install-by-dmg">Installation Guide</a></li>
+                <li><a href="//docs.fluentd.org/v1.0/articles/install-by-dmg">Installation Guide</a></li>
                 <li>
                   <a href="https://td-agent-package-browser.herokuapp.com/3/macosx">dmg repository</a>
                 </li>
@@ -152,7 +152,7 @@
                   <code>gem install fluentd</code><br/>
                 </li>
               </ul>
-              <a href="http://docs.fluentd.org/articles/install-by-gem">Installation Guide</a> (* ruby expert-use only)<br/>
+              <a href="//docs.fluentd.org/v1.0/articles/install-by-gem">Installation Guide</a> (* ruby expert-use only)<br/>
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
The Gem and macOS Installation Guide links are currently dead