### PR TITLE
Add missing Buster download link

### DIFF
--- a/views/download.erb
+++ b/views/download.erb
@@ -65,6 +65,7 @@
                   64-bit/amd64 (<a href="https://td-agent-package-browser.herokuapp.com/3/ubuntu/bionic/pool/contrib/t/td-agent">Bionic</a>,
                   <a href="https://td-agent-package-browser.herokuapp.com/3/ubuntu/xenial/pool/contrib/t/td-agent">Xenial</a>,
                   <a href="https://td-agent-package-browser.herokuapp.com/3/ubuntu/trusty/pool/contrib/t/td-agent">Trusty</a>)
+                  <a href="https://td-agent-package-browser.herokuapp.com/3/debian/buster/pool/contrib/t/td-agent">Buster</a>
                   <a href="https://td-agent-package-browser.herokuapp.com/3/debian/stretch/pool/contrib/t/td-agent">Stretch</a>,
                   <a href="https://td-agent-package-browser.herokuapp.com/3/debian/jessie/pool/contrib/t/td-agent">Jessie</a>
                 </li>


### PR DESCRIPTION
Even though Debian Buster is  listed in https://docs.fluentd.org/installation/install-by-deb but not for https://www.fluentd.org/download.