### PR TITLE
ga: switch Google Analytics Tag from TD to CNCF

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -3,6 +3,13 @@
 <!--[if IE 9]> <html lang="en" class="ie9"> <![endif]-->
 <!--[if !IE]><!--> <html lang="en"> <!--<![endif]-->
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-TFCP8WJ');</script>
+    <!-- End Google Tag Manager -->
+
     <%= ::NewRelic::Agent.browser_timing_header rescue "" %>
 
     <link href="/favicon.ico" rel="icon" type="image/x-icon" />
@@ -34,15 +41,10 @@
     <script>hljs.initHighlightingOnLoad();</script>
   </head>
   <body>
-    <!-- Google Tag Manager -->
-    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-T7BJ3X"
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TFCP8WJ"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-T7BJ3X');</script>
-    <!-- End Google Tag Manager -->
+    <!-- End Google Tag Manager (noscript) -->
 
     <!--Facebook-->
     <div id="fb-root"></div>


### PR DESCRIPTION
The following patch changes the Google Analayts Tag scripts from
the one used by Treasure Data to CNCF.

Since we don't find a way to transfer the GA account to CNCF, it's
easier to just setup a new one.

note: the scripts on this patch are provided by CNCF

Signed-off-by: Eduardo Silva <eduardo@treasure-data.com>