### PR TITLE
Add a public release for Fluentd v1.12.1

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -62,7 +62,7 @@ TD_AGENT_VERSIONS = {
     gem_v10: "0.10.61",
     gem_v12: "0.12.43",
     gem_v14: "0.14.25",
-    'gem_v1.0': '1.12.0'
+    'gem_v1.0': '1.12.1'
   },
   :v2 => {
     linux: "2.5.0",
@@ -74,7 +74,7 @@ TD_AGENT_VERSIONS = {
     win: "3.8.1"
   },
   :v4 => {
-    linux: "4.0.1",
+    linux: "4.1.0",
     win: "4.0.1"
   },
   :bit => {
@@ -102,6 +102,11 @@ AUTHORS = {
     'name' => 'Satoshi Tagomori',
     'avatar_url' => 'https://avatars3.githubusercontent.com/u/230654?v=3&s=70',
     'desc' => 'Satoshi (a.k.a. Moris) (<a href="https://twitter.com/tagomoris">@tagomoris</a>) is a maintainer of Fluentd. He works on Fluentd, many Fluentd plugins, other OSS projects like msgpack-ruby, Norikra and so on, and distributed systems at <a href="http://www.treasuredata.com/">Treasure Data</a>.'
+  },
+  'clearcode' => {
+    'name' => 'ClearCode, Inc.',
+    'avatar_url' => 'https://avatars.githubusercontent.com/u/176515?v=3&s=70',
+    'desc' => '<a href="https://www.clear-code.com/">ClearCode, Inc.</a> is a software company specializing in the development of Free Software. We maintain Fluentd and its plugin ecosystem, and provide commercial support for them.'
   },
 }
 

--- a/content/blog/20210218_fluentd-v1.12.1-has-been-released.md
+++ b/content/blog/20210218_fluentd-v1.12.1-has-been-released.md
@@ -1,0 +1,47 @@
+# Fluentd v1.12.1 has been released
+
+Hi users!
+
+We have released v1.12.1. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md).
+
+### `out_http`: A new option `headers_from_placeholders` added
+
+You can start using `headers_from_placeholders` to embed tags and record fields into HTTP headers.
+
+```
+headers_from_placeholders {"x-foo-bar":"${$.foo.bar}","x-tag":"app-${tag}"}
+<buffer tag,$.foo.bar>
+  # buffer parameters...
+</buffer>
+```
+
+### config-format: Markdown table support
+
+`fluent-plugin-config-format` is now able to show the list of configuration options using a Markdown table.
+
+```
+$ fluent-plugin-config-format -t input dummy
+...
+
+### Configuration
+
+|parameter|type|description|default|
+|---|---|---|---|
+|tag|string (required)|The value is the tag assigned to the generated events.||
+|size|integer (optional)|The number of events in event stream of each emits.|`1`|
+|rate|integer (optional)|It configures how many events to generate per second.|`1`|
+|auto_increment_key|string (optional)|If specified, each generated event has an auto-incremented key field.||
+|suspend|bool (optional)|The boolean to suspend-and-resume incremental value after restart<br>Deprecated: This parameters is ignored||
+|sample| (optional)|The sample data to be generated. An array of JSON hashes or a single JSON hash.<br>Alias: dummy|`[{"message"=>"sample"}]`|
+```
+
+### A new system option `disable_shared_socket` added
+
+You can now prevent Fluentd from creating a communication socket by setting `disable_shared_socket` option (or `--disable-shared-socket` command-line parameter).
+
+This option is useful, in particular, on Windows when you do not want Fluentd from occupying an ephemeral TCP port. Read [the documentation](https://docs.fluentd.org/deployment/system-config#disable_shared_socket) for details.
+
+Enjoy logging!
+
+TAG: Fluentd Announcement
+AUTHOR: clearcode


### PR DESCRIPTION
This adds a news blog post for Fluentd v1.12.1 which was released
February 18, 2021.

This also updates the latest version of TD Agent to v4.1.0, so that
[the release page](https://www.fluentd.org/download
) is kept updated.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>