### PR TITLE
Update td-agent for Windows to 4.1.0

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -75,7 +75,7 @@ TD_AGENT_VERSIONS = {
   },
   :v4 => {
     linux: "4.1.0",
-    win: "4.0.1"
+    win: "4.1.0"
   },
   :bit => {
     linux: "1.6.9"


### PR DESCRIPTION
We've uploaded the td-agent-4.1.0-x64.msi: https://td-agent-package-browser.herokuapp.com/4/windows