### PR TITLE
circleci: Upgrade to Ruby 2.6.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
-      - image: circleci/ruby:2.6.3
+      - image: circleci/ruby:2.6.6
     steps:
       - checkout
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -28,7 +28,7 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
-      - image: circleci/ruby:2.6.3
+      - image: circleci/ruby:2.6.6
     steps:
       - checkout
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS


### PR DESCRIPTION
Because deploying is broken as of #117
https://app.circleci.com/pipelines/github/fluent/fluentd-website/72/workflows/453fc419-d539-45fa-83fe-0f736d7e144b/jobs/549
