### PR TITLE
Update to Ruby 2.6.6 again

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ DEPENDENCIES
   yui-compressor
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 2.6.6p146
 
 BUNDLED WITH
    1.17.2


### PR DESCRIPTION
PR #117 lacks updadating Gemfile.lock
