### PR TITLE
Switch from yui-compressor to sassc,uglifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,8 @@ gem 'unicorn', '~> 5.4.0'
 gem 'unicorn-worker-killer', '~> 0.4.4'
 
 # Compressor
-gem 'yui-compressor', :require => 'yui/compressor'
+gem 'sassc'
+gem 'uglifier'
 
 # Addons
 gem 'newrelic_rpm', '~> 3.5.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     shotgun (0.9.2)
       rack (>= 1.0)
     simple_oauth (0.3.1)
@@ -96,6 +98,8 @@ GEM
       multipart-post (~> 2.0)
       naught (~> 1.0)
       simple_oauth (~> 0.3.0)
+    uglifier (4.2.0)
+      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
@@ -105,7 +109,6 @@ GEM
     unicorn-worker-killer (0.4.4)
       get_process_mem (~> 0)
       unicorn (>= 4, < 6)
-    yui-compressor (0.12.0)
 
 PLATFORMS
   ruby
@@ -118,15 +121,16 @@ DEPENDENCIES
   rake
   redcarpet
   redis
+  sassc
   shotgun (~> 0.9)
   sinatra (~> 2.1.0)
   sinatra-asset-pipeline (~> 2.2.1)
   slugify
   test-unit
   twitter
+  uglifier
   unicorn (~> 5.4.0)
   unicorn-worker-killer (~> 0.4.4)
-  yui-compressor
 
 RUBY VERSION
    ruby 2.6.6p146

--- a/app.rb
+++ b/app.rb
@@ -21,8 +21,8 @@ end
 set :root, __dir__
 set :assets_precompile, %w(application.css application.js newsletter.css pages/lunr.min.js respond.js)
 set :assets_paths, %w(assets/css assets/js assets/plugins)
-set :assets_css_compressor, :yui
-set :assets_js_compressor, :yui
+set :assets_css_compressor, :sassc
+set :assets_js_compressor, :uglifier
 Sinatra.register Sinatra::AssetPipeline
 
 MARKDOWN = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, tables: true, fenced_code_blocks: true)


### PR DESCRIPTION
As yui-compressor is not maintained anymore [1], so
it should migrate from it.

The past PR [2] tried to migrate to sass and uglifier, but now sass is
also deprecated. so sassc and uglifier are the reasonable choice for
migration.

[1] https://rubygems.org/gems/yui-compressor
[2] https://github.com/fluent/fluentd-website/pull/78/commits/71f175814fd902fd5d4c2dc151b0e66e2d84c540
[3] https://sass-lang.com/ruby-sass

Signed-off-by: Kentaro Hayashi <hayashi@clear-code.com>