### PR TITLE
Add links to https://discuss.fluentd.org/

### DIFF
--- a/views/_right_menu.erb
+++ b/views/_right_menu.erb
@@ -14,6 +14,7 @@
   <div class="headline"><h2>Ask the Community</h2></div>
   <p>Couldn't find enough information? Let's ask the community!</p>
   <ul class="list-unstyled">
+    <li><i class="icon-ok color-green"></i><a target="_blank" href="https://discuss.fluentd.org">Forum (Recommended)</a></li>
     <li><i class="icon-ok color-green"></i><a target="_blank" href="https://groups.google.com/forum/#!forum/fluentd">Google Group</a></li>
     <li><i class="icon-ok color-green"></i><a target="_blank" href="/newsletter">News Letter</a></li>
     <li><i class="icon-stackexchange color-green"></i><a target="_blank" href="http://stackoverflow.com/questions/tagged/fluentd">Stack Overflow</a></li>

--- a/views/community.erb
+++ b/views/community.erb
@@ -16,8 +16,15 @@
     <div class="col-md-9">
       <div class="clients-page margin-bottom-20">
         <img src="/images/env_icon.png" alt="" />
+        <p><h3><a href="https://discuss.fluentd.org">Forum</a></h3>
+          Got a question? Have some cool Fluentd-related projects? The forum is the place to be.
+        </p>
+      </div>
+
+      <div class="clients-page margin-bottom-20">
+        <img src="/images/env_icon.png" alt="" />
         <p><h3><a href="https://groups.google.com/forum/#!forum/fluentd">Mailing List</a></h3>
-          Got a question? Have some cool Fluentd-related projects? The mailing list is the place to be.
+          We are migrating to the new <a href="https://discuss.fluentd.org">Forum</a> above, so please don't post new articles here.
         </p>
       </div>
 

--- a/views/contributing.erb
+++ b/views/contributing.erb
@@ -22,7 +22,7 @@
         Resources of <a href="http://www.fluentd.org">Official site and <a href="http://docs.fluentd.org">Fluentd documentation</a> may help you.
       </p>
       <p>
-        If you have further questions about Fluentd and plugins, please direct these to <a href="https://groups.google.com/forum/#!forum/fluentd">Mailing List</a>.
+        If you have further questions about Fluentd and plugins, please direct these to <a href="https://discuss.fluentd.org">Forum</a>.
       </p>
       <p>
         Don't use Github issue for asking questions. Here are examples:

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -231,6 +231,7 @@
             <div class="margin-bottom-20">
               <div class="headline"><h2>Community</h2></div>
               <ul class="list-unstyled">
+                <li><i class="icon-ok color-green"></i><a target="_blank" href="https://discuss.fluentd.org">Forum (Recommended)</a></li>
                 <li><i class="icon-ok color-green"></i><a target="_blank" href="https://groups.google.com/forum/#!forum/fluentd">Google Group</a></li>
                 <li><i class="icon-stackexchange color-green"></i><a target="_blank" href="https://stackoverflow.com/questions/tagged/fluentd">Stack Overflow</a></li>
                 <li><i class="icon-github-alt color-green"></i><a target="_blank" href="https://github.com/fluent/fluentd/issues">Issue Tracker</a></li>


### PR DESCRIPTION
We are migrating Forum / Mailing List to Discourse.
We will deprecate Google Groups (https://groups.google.com/group/fluentd).

See also: https://groups.google.com/g/fluentd/c/z6e4ziIfzdo
