### PR TITLE
Migrate to Puma application server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,7 @@ gem 'slugify'
 gem 'redis'
 
 # Webserver
-gem 'unicorn', '~> 5.4.0'
-gem 'unicorn-worker-killer', '~> 0.4.4'
+gem 'puma'
 
 # Compressor
 gem 'sassc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,8 +15,6 @@ GEM
     execjs (2.7.0)
     ffi (1.11.1)
     ffi (1.11.1-x86-mingw32)
-    get_process_mem (0.2.4)
-      ffi (~> 1.0)
     http (3.3.0)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -27,7 +25,6 @@ GEM
     http-form_data (2.1.1)
     http_parser.rb (0.6.0)
     jemalloc (1.0.1)
-    kgio (2.11.2)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     mini_portile2 (2.5.0)
@@ -36,6 +33,7 @@ GEM
       ruby2_keywords (~> 0.0.1)
     naught (1.1.0)
     newrelic_rpm (3.5.8.72)
+    nio4r (2.5.7)
     nokogiri (1.11.0)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -43,11 +41,12 @@ GEM
       racc (~> 1.4)
     power_assert (1.1.5)
     public_suffix (3.1.1)
+    puma (5.2.2)
+      nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-protection (2.1.0)
       rack
-    raindrops (0.19.0)
     rake (12.3.3)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
@@ -103,12 +102,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
-    unicorn (5.4.1)
-      kgio (~> 2.6)
-      raindrops (~> 0.7)
-    unicorn-worker-killer (0.4.4)
-      get_process_mem (~> 0)
-      unicorn (>= 4, < 6)
 
 PLATFORMS
   ruby
@@ -118,6 +111,7 @@ DEPENDENCIES
   jemalloc (~> 1.0.1)
   newrelic_rpm (~> 3.5.4)
   nokogiri
+  puma
   rake
   redcarpet
   redis
@@ -129,8 +123,6 @@ DEPENDENCIES
   test-unit
   twitter
   uglifier
-  unicorn (~> 5.4.0)
-  unicorn-worker-killer (~> 0.4.4)
 
 RUBY VERSION
    ruby 2.6.6p146

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec je unicorn -c lib/unicorn/config.rb -p $PORT
+web: bundle exec puma -C config/puma.rb -p $PORT

--- a/config.ru
+++ b/config.ru
@@ -1,15 +1,6 @@
 require 'bundler/setup'
 require './app.rb'
 
-# Unicorn self-process killer
-require 'unicorn/worker_killer'
-use Unicorn::WorkerKiller::MaxRequests, 10240 + Random.rand(10240)
-use Unicorn::WorkerKiller::Oom, (96 + Random.rand(32)) * (1024**2)
-
-# Out-Of-Band GC
-require 'unicorn/oob_gc'
-use Unicorn::OobGC
-
 # Compression
 use Rack::Deflater
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,15 @@
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'
+
+on_worker_boot do
+  # Worker specific setup for Rails 4.1+
+  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
+  ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
Puma is Now the Recommended Ruby Webserver
https://devcenter.heroku.com/changelog-items/594

Since January 2015, Puma is recommended web server
on Heroku.
