### PR TITLE
circleci: Force push the git repository to Heroku

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - run:
           name: Deploy
           command: |
-            git push https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME.git master
+            git push -f https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME.git master
             $REFRESH_CACHE_COMMAND
 
 workflows:


### PR DESCRIPTION
Currently the master branch on Heroku is conflicting with GitHub's one.

https://app.circleci.com/pipelines/github/fluent/fluentd-website/85/workflows/49151be9-989f-4ec3-ab16-00617ad6fed5/jobs/575

```
  To https://git.heroku.com/******************.git
   ! [rejected]        master -> master (fetch first)
  error: failed to push some refs to 'https://heroku:************************************@git.heroku.com/******************.git'
  hint: Updates were rejected because the remote contains work that you do
  hint: not have locally. This is usually caused by another repository pushing
  hint: to the same ref. You may want to first integrate the remote changes
  hint: (e.g., 'git pull ...') before pushing again.
  hint: See the 'Note about fast-forwards' in 'git push --help' for details.
```

It should be always synchronized with GitHub even if a maintainer pushed
local modifications.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>