### PR TITLE
Replace a link for td-agent issue tracker

### DIFF
--- a/views/contributing.erb
+++ b/views/contributing.erb
@@ -50,7 +50,7 @@
       </ul>
       <p>
         If you find a bug of 3rd party plugins, please submit an issue to each plugin repository.
-        And use <a href="https://github.com/treasure-data/omnibus-td-agent">omnibus-td-agent</a> repository for td-agent releated issues.
+        And use <a href="https://github.com/fluent-plugins-nursery/fluent-package-builder">fluent-package-builder</a> repository for td-agent releated issues.
       </p>
 
       <h3>Patch Guidelines</h3>


### PR DESCRIPTION
We migrated it from omnibus-td-agent to fluent-package-builder:

* Before: https://github.com/treasure-data/omnibus-td-agent/
* After:  https://github.com/fluent-plugins-nursery/fluent-package-builder

Signed-off-by: Takuro Ashie <ashie@clear-code.com>