### PR TITLE
Drop Disqus integration

### DIFF
--- a/views/blog_single.erb
+++ b/views/blog_single.erb
@@ -54,22 +54,6 @@
 
       <hr/>
 
-      <!-- Disqus -->
-      <div id="disqus_thread"></div>
-      <script type="text/javascript">
-        /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-        var disqus_shortname = 'fluentd-blog'; // required: replace example with your forum shortname
-
-        /* * * DON'T EDIT BELOW THIS LINE * * */
-        (function() {
-        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-        })();
-      </script>
-      <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-      <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
-
     </div>
     <!-- End Left Sidebar -->
 


### PR DESCRIPTION
fluentd-blog.disqus.com is not managed by Fluentd team
and it seems that no one owns admin privilege.

This situation is not welcoming status, so drop it.

The following area will be  dropped from each blog entry.

![image](https://user-images.githubusercontent.com/225841/146505418-17aa3eab-0497-4613-968a-95a73ee29c1f.png)
