### PR TITLE
Remove Google+ links from the website

### DIFF
--- a/views/blog.erb
+++ b/views/blog.erb
@@ -121,7 +121,6 @@
         <ul class="social-icons">
           <li><a href="https://twitter.com/fluentd" data-original-title="Twitter" class="social_twitter"></a></li>
           <li><a href="https://www.facebook.com/pages/Fluentd/196064987183037" data-original-title="Facebook" class="social_facebook"></a></li>
-          <li><a href="https://plus.google.com/b/101058615563686673102/" data-original-title="Google Plus" class="social_googleplus"></a></li>
           <li><a href="http://vimeo.com/tag:fluentd" data-original-title="Vimeo" class="social_vimeo"></a></li>
           <li><a href="/blog/feed.rss" data-original-title="Blog RSS" class="social_rss"></a></li>
         </ul>

--- a/views/blog_single.erb
+++ b/views/blog_single.erb
@@ -94,7 +94,6 @@
         <ul class="social-icons">
           <li><a href="https://twitter.com/fluentd" data-original-title="Twitter" class="social_twitter"></a></li>
           <li><a href="https://www.facebook.com/pages/Fluentd/196064987183037" data-original-title="Facebook" class="social_facebook"></a></li>
-          <li><a href="https://plus.google.com/b/101058615563686673102/" data-original-title="Google Plus" class="social_googleplus"></a></li>
           <li><a href="http://vimeo.com/tag:fluentd" data-original-title="Vimeo" class="social_vimeo"></a></li>
           <li><a href="/blog/feed.rss" data-original-title="Blog RSS" class="social_rss"></a></li>
         </ul>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -230,7 +230,6 @@
               <ul class="social-icons">
                 <li><a href="https://www.facebook.com/pages/Fluentd/196064987183037" data-original-title="Facebook" class="social_facebook"></a></li>
                 <li><a href="https://twitter.com/fluentd" data-original-title="Twitter" class="social_twitter"></a></li>
-                <li><a href="https://plus.google.com/b/101058615563686673102/" data-original-title="Google Plus" class="social_googleplus"></a></li>
                 <li><a href="https://vimeo.com/tag:fluentd" data-original-title="Vimeo" class="social_vimeo"></a></li>
                 <li><a href="/blog/feed.rss" data-original-title="Blog" class="social_rss"></a></li>
               </ul>


### PR DESCRIPTION
This link leads to the following announcemenet page:

    In December 2018, we announced our decision to shut down
    Google+ for consumers in April 2019.

So these Google+ links are not being workign since 2 years ago
at least. Remove them.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>