### PR TITLE
Update Ruby to 2.7.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # https://devcenter.heroku.com/articles/ruby-support#supported-runtimes
-ruby '2.6.8'
+ruby '2.7.5'
 
 # Framework
 gem 'sinatra', '~> 2.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ DEPENDENCIES
   uglifier
 
 RUBY VERSION
-   ruby 2.6.8p205
+   ruby 2.7.5p203
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
2.6.x will reach EOL at March, 2022.

It seems okay with % git push heroku master.
