### PR TITLE
Follow updated CHANGELOG.md heading styles

### DIFF
--- a/content/blog/20210529_fluentd-v1.13.0-has-been-released.md
+++ b/content/blog/20210529_fluentd-v1.13.0-has-been-released.md
@@ -2,7 +2,7 @@
 
 Hi users!
 
-We have released v1.13.0. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#v113).
+We have released v1.13.0. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#release-v1130---20210529).
 
 There are some topics in this release.
 

--- a/content/blog/20210625_fluentd-v1.13.1-has-been-released.md
+++ b/content/blog/20210625_fluentd-v1.13.1-has-been-released.md
@@ -2,7 +2,7 @@
 
 Hi users!
 
-We have released v1.13.1. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#v1131).
+We have released v1.13.1. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#release-v1131---20210625).
 
 This release is a maintenance release of v1.13 series.
 

--- a/content/blog/20210712_fluentd-v1.13.2-has-been-released.md
+++ b/content/blog/20210712_fluentd-v1.13.2-has-been-released.md
@@ -2,7 +2,7 @@
 
 Hi users!
 
-We have released v1.13.2. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#v1132).
+We have released v1.13.2. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#release-v1132---20210712).
 
 This release is a maintenance release of v1.13 series.
 We recommend to upgrade Fluentd because it contains fixes about crash bugs.

--- a/content/blog/20210727_fluentd-v1.13.3-has-been-released.md
+++ b/content/blog/20210727_fluentd-v1.13.3-has-been-released.md
@@ -2,7 +2,7 @@
 
 Hi users!
 
-We have released v1.13.3. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#v1133).
+We have released v1.13.3. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#release-v1133---20210727).
 
 This release is a maintenance release of v1.13 series.
 We recommend to upgrade Fluentd because it contains fixes about `in_tail` bugs.

--- a/content/blog/20210830_fluentd-v1.14.0-has-been-released.md
+++ b/content/blog/20210830_fluentd-v1.14.0-has-been-released.md
@@ -2,7 +2,7 @@
 
 Hi users!
 
-We have released v1.14.0. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#v1140).
+We have released v1.14.0. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#release-v1140---20210830).
 
 This release is a new release of v1.14 series.
 We recommend to upgrade Fluentd because it contains fixes about `in_tail` bugs

--- a/content/blog/20210929_fluentd-v1.14.1-has-been-released.md
+++ b/content/blog/20210929_fluentd-v1.14.1-has-been-released.md
@@ -2,7 +2,7 @@
 
 Hi users!
 
-We have released v1.14.1. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#release-v1141---20210829).
+We have released v1.14.1. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#release-v1141---20210929).
 
 This release is a maintenance release of v1.14 series.
 

--- a/content/blog/20210929_fluentd-v1.14.1-has-been-released.md
+++ b/content/blog/20210929_fluentd-v1.14.1-has-been-released.md
@@ -2,7 +2,7 @@
 
 Hi users!
 
-We have released v1.14.1. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#v1141).
+We have released v1.14.1. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#release-v1141---20210829).
 
 This release is a maintenance release of v1.14 series.
 

--- a/content/blog/20211029_fluentd-v1.14.2-has-been-released.md
+++ b/content/blog/20211029_fluentd-v1.14.2-has-been-released.md
@@ -2,7 +2,7 @@
 
 Hi users!
 
-We have released v1.14.2. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#v1142).
+We have released v1.14.2. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#release-v1142---20211029).
 
 This release is a maintenance release of v1.14 series.
 

--- a/content/blog/20211126_fluentd-v1.14.3-has-been-released.md
+++ b/content/blog/20211126_fluentd-v1.14.3-has-been-released.md
@@ -2,7 +2,7 @@
 
 Hi users!
 
-We have released v1.14.3. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#v1143).
+We have released v1.14.3. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#release-v1143---20211126).
 
 This release is a maintenance release of v1.14 series.
 

--- a/content/blog/20220106_fluentd-v1.14.4-has-been-released.md
+++ b/content/blog/20220106_fluentd-v1.14.4-has-been-released.md
@@ -2,7 +2,7 @@
 
 Hi users!
 
-We have released v1.14.4. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#v1144).
+We have released v1.14.4. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#release-v1144---20220106).
 
 This release is a maintenance release of v1.14 series.
 

--- a/content/blog/20220209_fluentd-v1.14.5-has-been-released.md
+++ b/content/blog/20220209_fluentd-v1.14.5-has-been-released.md
@@ -2,7 +2,7 @@
 
 Hi users!
 
-We have released v1.14.5. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#v1145).
+We have released v1.14.5. ChangeLog is [here](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md#release-v1145---20220209).
 
 This release is a maintenance release of v1.14 series.
 


### PR DESCRIPTION

Recently, it was found that the heading style in CHANGELOG.md was unexpectedly changed.
It has been fixed with https://github.com/fluent/fluentd/pull/3648.
Then blog entries that contain links to CHANGELOG.md should be also updated.

