### PR TITLE
Add RHEL9 and Ubuntu Jammy to download page

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -48,7 +48,7 @@ TD_AGENT_VERSIONS = {
   :v4 => {
     linux: "4.3.2",
     mac: "4.3.2",
-    win: "4.3.1.2"
+    win: "4.3.2"
   },
   :bit => {
     linux: "1.6.9"

--- a/views/download.erb
+++ b/views/download.erb
@@ -43,12 +43,14 @@
               <ul>
                 <li>
                   x86_64:
+                  <a href="https://td-agent-package-browser.herokuapp.com/4/redhat/9/x86_64">RHEL9</a>,
                   <a href="https://td-agent-package-browser.herokuapp.com/4/redhat/8/x86_64">RHEL8</a>,
                   <a href="https://td-agent-package-browser.herokuapp.com/4/redhat/7/x86_64">RHEL7</a>,
                   <a href="https://td-agent-package-browser.herokuapp.com/4/amazon/2/x86_64">Amazon Linux 2</a>
                 </li>
                 <li>
                   aarch64:
+                  <a href="https://td-agent-package-browser.herokuapp.com/4/redhat/9/aarch64">RHEL9</a>,
                   <a href="https://td-agent-package-browser.herokuapp.com/4/redhat/8/aarch64">RHEL8</a>,
                   <a href="https://td-agent-package-browser.herokuapp.com/4/redhat/7/aarch64">RHEL7</a>,
                   <a href="https://td-agent-package-browser.herokuapp.com/4/amazon/2/aarch64">Amazon Linux 2</a>
@@ -76,6 +78,7 @@
               <span style="font-weight:bold">td-agent v<%=TD_AGENT_VERSIONS[:v4][:linux]%></span>
               <ul>
                 <li>Ubuntu:
+                  <a href="https://td-agent-package-browser.herokuapp.com/4/ubuntu/jammy/pool/contrib/t/td-agent">Jammy</a>,
                   <a href="https://td-agent-package-browser.herokuapp.com/4/ubuntu/focal/pool/contrib/t/td-agent">Focal</a>,
                   <a href="https://td-agent-package-browser.herokuapp.com/4/ubuntu/bionic/pool/contrib/t/td-agent">Bionic</a>,
                   <a href="https://td-agent-package-browser.herokuapp.com/4/ubuntu/xenial/pool/contrib/t/td-agent">Xenial</a>


### PR DESCRIPTION
In addition, fix wrong version number for Windows.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>