### PR TITLE
Update Ruby to v3.2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
-      - image: circleci/ruby:2.7.5
+      - image: cimg/ruby:3.2.2
     steps:
       - checkout
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
@@ -28,7 +28,7 @@ jobs:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
-      - image: circleci/ruby:2.7.5
+      - image: cimg/ruby:3.2.2
     steps:
       - checkout
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,11 @@
 source 'https://rubygems.org'
 
 # https://devcenter.heroku.com/articles/ruby-support#supported-runtimes
-ruby '2.7.5'
+ruby '3.2.2'
 
 # Framework
 gem 'sinatra', '~> 2.2.3'
-gem 'sinatra-asset-pipeline', '~> 2.2.1'
-gem 'jemalloc', '~> 1.0.1'
+gem 'sinatra-asset-pipeline', git: 'https://github.com/ashie/sinatra-asset-pipeline.git', ref: '4fda55a4ab990396008b95eea246feea0cb256b2'
 gem 'redcarpet'
 gem 'slugify'
 
@@ -18,12 +17,11 @@ gem 'sassc'
 gem 'uglifier'
 
 # Addons
-gem 'newrelic_rpm', '~> 3.5.4'
+gem 'newrelic_rpm', '~> 9.2.2'
 
 # Dev
 group :development do
   gem 'rake'
-  gem 'shotgun', '~> 0.9'
   gem 'test-unit'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,27 @@
+GIT
+  remote: https://github.com/ashie/sinatra-asset-pipeline.git
+  revision: 4fda55a4ab990396008b95eea246feea0cb256b2
+  ref: 4fda55a4ab990396008b95eea246feea0cb256b2
+  specs:
+    sinatra-asset-pipeline (2.2.1)
+      coffee-script (~> 2.4)
+      rake (>= 12.3, < 14)
+      sass (~> 3.5)
+      sinatra (~> 2.0)
+      sprockets (~> 3.7)
+      sprockets-helpers (~> 1.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
-    buftok (0.2.0)
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
+    buftok (0.3.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     equalizer (0.0.11)
@@ -17,43 +30,40 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    http (4.4.1)
-      addressable (~> 2.3)
+    http (5.1.1)
+      addressable (~> 2.8)
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
-      http-parser (~> 1.2.0)
+      llhttp-ffi (~> 0.4.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    http-parser (1.2.3)
-      ffi-compiler (>= 1.0, < 2.0)
-    http_parser.rb (0.6.0)
-    jemalloc (1.0.1)
+    llhttp-ffi (0.4.0)
+      ffi-compiler (~> 1.0)
+      rake (~> 13.0)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
-    mini_portile2 (2.8.1)
-    multipart-post (2.2.3)
+    multipart-post (2.3.0)
     mustermann (2.0.2)
       ruby2_keywords (~> 0.0.1)
     naught (1.1.0)
-    newrelic_rpm (3.5.8.72)
-    nio4r (2.5.8)
-    nokogiri (1.14.3)
-      mini_portile2 (~> 2.8.0)
+    newrelic_rpm (9.2.2)
+    nio4r (2.5.9)
+    nokogiri (1.15.0-x86_64-linux)
       racc (~> 1.4)
-    power_assert (2.0.1)
-    public_suffix (4.0.7)
-    puma (5.6.4)
+    power_assert (2.0.3)
+    public_suffix (5.0.1)
+    puma (6.2.2)
       nio4r (~> 2.0)
     racc (1.6.2)
-    rack (2.2.6.4)
-    rack-protection (2.2.3)
+    rack (2.2.7)
+    rack-protection (2.2.4)
       rack
-    rake (12.3.3)
-    rb-fsevent (0.11.1)
+    rake (13.0.6)
+    rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redcarpet (3.5.1)
+    redcarpet (3.6.0)
     ruby2_keywords (0.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -62,38 +72,29 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
     sassc (2.4.0)
       ffi (~> 1.9)
-    shotgun (0.9.2)
-      rack (>= 1.0)
     simple_oauth (0.3.1)
-    sinatra (2.2.3)
+    sinatra (2.2.4)
       mustermann (~> 2.0)
       rack (~> 2.2)
-      rack-protection (= 2.2.3)
+      rack-protection (= 2.2.4)
       tilt (~> 2.0)
-    sinatra-asset-pipeline (2.2.1)
-      coffee-script (~> 2.4)
-      rake (~> 12.3)
-      sass (~> 3.5)
-      sinatra (~> 2.0)
-      sprockets (~> 3.7)
-      sprockets-helpers (~> 1.2)
     slugify (1.0.7)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-helpers (1.4.0)
       sprockets (>= 2.2)
-    test-unit (3.5.3)
+    test-unit (3.5.8)
       power_assert
     thread_safe (0.3.6)
-    tilt (2.0.11)
-    twitter (7.0.0)
+    tilt (2.1.0)
+    twitter (8.0.0)
       addressable (~> 2.3)
-      buftok (~> 0.2.0)
+      buftok (~> 0.3.0)
       equalizer (~> 0.0.11)
-      http (~> 4.0)
-      http-form_data (~> 2.0)
-      http_parser.rb (~> 0.6.0)
+      http (~> 5.1)
+      http-form_data (~> 2.3)
+      llhttp-ffi (~> 0.4.0)
       memoizable (~> 0.4.0)
       multipart-post (~> 2.0)
       naught (~> 1.0)
@@ -105,26 +106,24 @@ GEM
     unf_ext (0.0.8.2)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
-  jemalloc (~> 1.0.1)
-  newrelic_rpm (~> 3.5.4)
+  newrelic_rpm (~> 9.2.2)
   nokogiri
   puma
   rake
   redcarpet
   sassc
-  shotgun (~> 0.9)
   sinatra (~> 2.2.3)
-  sinatra-asset-pipeline (~> 2.2.1)
+  sinatra-asset-pipeline!
   slugify
   test-unit
   twitter
   uglifier
 
 RUBY VERSION
-   ruby 2.7.5p203
+   ruby 3.2.2p53
 
 BUNDLED WITH
-   2.3.9
+   2.4.13

--- a/Rakefile
+++ b/Rakefile
@@ -7,12 +7,7 @@ require_relative './app'
 Sinatra::AssetPipeline::Task.define! Sinatra::Application
 
 task :server do
-  if which('shotgun')
-    exec 'shotgun -O app.rb -p 9200 -o 0.0.0.0'
-  else
-    warn 'warn: shotgun not installed; reloading is disabled.'
-      exec 'ruby -rubygems app.rb -p 9395'
-  end
+  exec 'ruby app.rb -p 9395'
 end
 def which(command)
   ENV['PATH'].

--- a/app.rb
+++ b/app.rb
@@ -139,7 +139,7 @@ get '/guides' do
 end
 
 get '/guides/recipes/:type' do
-  pass if not File.exists? "content/guides/recipes/#{params[:type]}.md"
+  pass if not File.exist? "content/guides/recipes/#{params[:type]}.md"
   @title, @content = read_markdown("content/guides/recipes/#{params[:type]}.md")
   erb :solution_recipe
 end
@@ -176,7 +176,7 @@ get '/datasources' do
 end
 
 get '/datasources/:type' do
-  pass if not File.exists? "content/datasources/#{params[:type]}.md"
+  pass if not File.exist? "content/datasources/#{params[:type]}.md"
   @title, @content = read_markdown("content/datasources/#{params[:type]}.md")
   erb :datasource_how
 end
@@ -187,7 +187,7 @@ get '/dataoutputs' do
 end
 
 get '/dataoutputs/:type' do
-  pass if not File.exists? "content/dataoutputs/#{params[:type]}.md"
+  pass if not File.exist? "content/dataoutputs/#{params[:type]}.md"
   @title, @content = read_markdown("content/dataoutputs/#{params[:type]}.md")
   erb :dataoutput_how
 end
@@ -195,7 +195,7 @@ end
 get '/casestudy/:company' do
   @company = params[:company]
   path_to_file = "content/casestudy/#{@company}.md"
-  pass if not File.exists? path_to_file
+  pass if not File.exist? path_to_file
   @casestudy_title, body_content = File.new(path_to_file).read.split("\n", 2)
   @casestudy_title.gsub!(/^#+/, "")
   @title = @casestudy_title

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,7 +4,7 @@ threads threads_count, threads_count
 
 preload_app!
 
-rackup      DefaultRackup
+rackup      DefaultRackup if defined?(DefaultRackup)
 port        ENV['PORT']     || 3000
 environment ENV['RACK_ENV'] || 'development'
 


### PR DESCRIPTION
* Dependent gems are also updated
* Remove shotgun because it doesn't support Ruby 3
* Use latest version of shinatra-asset-pipeline in GitHub to resolve conflict of required rake version
  * To make sure to exist the specified revision, use our fork repository
* Replace `File.exists?` with `File.exist?`
* Remove jemalloc gem because it doesn't seem used in actual and it uses `File.exists?`