### PR TITLE
Reduce crontab frequency

### DIFF
--- a/.github/workflows/update-plugins.yaml
+++ b/.github/workflows/update-plugins.yaml
@@ -2,7 +2,7 @@ name: Update plugins
 
 on:
   schedule:
-    - cron: '8 14 * * *'
+    - cron: '8 14 * * 0'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Changed to update them (weekly) at 14:08 on Sunday.

It seems that there is no need to update plugin metadata every day.