### PR TITLE
Reduce frequency to update plugins.json

### DIFF
--- a/scripts/plugins.rb
+++ b/scripts/plugins.rb
@@ -81,11 +81,17 @@ class Plugins
       puts "added: #{added_plugins}"
       puts "deleted: #{deleted_plugins}"
     end
-    if added_plugins.size > 0 or deleted_plugins.size > 0
+    if added_plugins.size > 0 or deleted_plugins.size > 0 or force_update?
       File.open(File.join(__dir__, "plugins.json"), "w") do |file|
         file.write(JSON.pretty_generate(plugins))
       end
     end
+  end
+
+  def self.force_update?
+    duration = Time.now.to_i - File.mtime("plugins.json").to_i
+    seconds_in_a_week = 60 * 60 * 24 * 7
+    duration > seconds_in_a_week
   end
 
   OBSOLETE_PLUGINS = YAML.load_file(File.expand_path(File.join(__dir__, 'obsolete-plugins.yml')))

--- a/scripts/plugins.rb
+++ b/scripts/plugins.rb
@@ -72,8 +72,19 @@ class Plugins
       }
     }
 
-    File.open(File.join(__dir__, "plugins.json"), "w") do |file|
-      file.write(JSON.pretty_generate(plugins))
+    previous_plugins = YAML.load_file("plugins.json").collect { |plugin| plugin["name"] }
+    current_plugins = plugins.collect { |plugin| plugin[:name] }
+    # When the number of plugin is changed, update it.
+    deleted_plugins = previous_plugins - current_plugins
+    added_plugins = current_plugins - previous_plugins
+    if ENV["DEBUG"]
+      puts "added: #{added_plugins}"
+      puts "deleted: #{deleted_plugins}"
+    end
+    if added_plugins.size > 0 or deleted_plugins.size > 0
+      File.open(File.join(__dir__, "plugins.json"), "w") do |file|
+        file.write(JSON.pretty_generate(plugins))
+      end
     end
   end
 


### PR DESCRIPTION
Another approach #269 

Before:
  * Update plugins.json every day

After:
  * Update plugins.json when the number of plugin is changed.
  * Reduce commit just update "downloads" field. Note that "downloads" may be inaccurate.