### PR TITLE
github: upgrade to checkout@v3

### DIFF
--- a/.github/workflows/update-plugins.yaml
+++ b/.github/workflows/update-plugins.yaml
@@ -9,7 +9,7 @@ jobs:
   update-plugins:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
checkout@v2 uses deprecated node12.