### PR TITLE
Tweak updating plugins

### DIFF
--- a/.github/workflows/update-plugins.yaml
+++ b/.github/workflows/update-plugins.yaml
@@ -21,5 +21,4 @@ jobs:
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}"@users.noreply.github.com
           git add scripts/plugins.json
-          git commit -m "Update plugins.json"
-          git push origin master
+          git commit -m "Update plugins.json" && git push origin master || echo "No need to update"

--- a/scripts/plugins.rb
+++ b/scripts/plugins.rb
@@ -6,6 +6,7 @@ require 'net/https'
 require 'cgi'
 require 'erb'
 require 'yaml'
+require 'time'
 
 def e(s)
   CGI.escape(s.to_s)
@@ -93,7 +94,8 @@ class Plugins
   end
 
   def self.force_update?
-    duration = Time.now.to_i - File.mtime(plugins_json).to_i
+    last_modified = Time.parse(`git log -1 --pretty="format:%ci" #{plugins_json}`)
+    duration = Time.now.to_i - last_modified.to_i
     seconds_in_a_week = 60 * 60 * 24 * 7
     duration > seconds_in_a_week
   end


### PR DESCRIPTION
It seems that there are 2 problems on updating plugins in #276 and #279

* Result of the job is treated as failed even when plugins.json isn't needed to update
  * https://github.com/fluent/fluentd-website/actions/runs/5939986157/job/16107594763#step:5:13
* plugins.json isn't updated even though 7 days passed from last update