### PR TITLE
GHA: Specify fetch-depth for actions/checkout to get history of plugins.json

### DIFF
--- a/.github/workflows/update-plugins.yaml
+++ b/.github/workflows/update-plugins.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Without this, scripts/plugins.rb can't check the last commit date of plugins.json correctly on GitHub Actions.