### PR TITLE
Add missing homepage_uri parameter

### DIFF
--- a/scripts/plugins.rb
+++ b/scripts/plugins.rb
@@ -69,7 +69,8 @@ class Plugins
         info: p["info"],
         authors: p["authors"],
         version: p["version"],
-        downloads: p["downloads"]
+        downloads: p["downloads"],
+        homepage_uri: p["homepage_uri"]
       }
     }
 


### PR DESCRIPTION
homepage_uri is used for https://www.fluentd.org/plugins/all.