### PR TITLE
td-agent v4.5.3 for Windows has been released

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -47,7 +47,7 @@ TD_AGENT_VERSIONS = {
   :v4 => {
     linux: "4.5.2",
     mac: "4.5.2",
-    win: "4.5.2"
+    win: "4.5.3"
   },
   :bit => {
     linux: "1.6.9"


### PR DESCRIPTION
It fixes a fatal launch failure issue due to non-ASCII registry key.