### PR TITLE
blog: always show major topics

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -247,6 +247,9 @@ get '/blog/' do
   @title = "Blog"
   @articles = read_blog_articles(Dir.glob("content/blog/*.md").sort.reverse.take(5))
   @recent_articles = read_blog_articles(Dir.glob("content/blog/*.md").sort.reverse.take(N_RECENT_POSTS))
+  @recent_reminder = read_blog_articles(Dir.glob("content/blog/*.md").sort.reverse).select do |article|
+    article[:tags].include?("reminder")
+  end
   erb :blog
 end
 
@@ -274,6 +277,9 @@ get '/blog/:article' do
   @article = read_blog_article(files.first)
   @title = @article[:title]
   @recent_articles = read_blog_articles(Dir.glob("content/blog/*.md").sort.reverse.take(N_RECENT_POSTS))
+  @recent_reminder = read_blog_articles(Dir.glob("content/blog/*.md").sort.reverse).select do |article|
+    article[:tags].include?("reminder")
+  end
   erb :blog_single
 end
 
@@ -283,6 +289,9 @@ get '/blog/tag/:tag' do
   article_paths = urls.map do |url| "content#{url}.md" end
   @articles = read_blog_articles(article_paths)
   @recent_articles = read_blog_articles(Dir.glob("content/blog/*.md").sort.reverse.take(N_RECENT_POSTS))
+  @recent_reminder = read_blog_articles(Dir.glob("content/blog/*.md").sort.reverse).select do |article|
+    article[:tags].include?("reminder")
+  end
   erb :blog
 end
 

--- a/content/blog/20230731_upgrade-td-agent-v4-to-v5.md
+++ b/content/blog/20230731_upgrade-td-agent-v4-to-v5.md
@@ -287,5 +287,5 @@ Now, upgrading steps are completed. Happy Logging!
 WARNING: Currently we have no plan to officially support dmg version of `fluent-package` yet.
 It is just modified to be a minimally buildable state, it is for testing purpose only.
 
-TAG: Fluentd td-agent fluent-package Announcement
+TAG: Fluentd td-agent fluent-package Announcement reminder
 AUTHOR: clearcode

--- a/content/blog/20230829_fluent-package-scheduled-lifecycle.md
+++ b/content/blog/20230829_fluent-package-scheduled-lifecycle.md
@@ -108,5 +108,5 @@ gantt
 
 Happy logging!
 
-TAG: Fluentd fluent-package Announcement
+TAG: Fluentd fluent-package Announcement reminder
 AUTHOR: clearcode

--- a/content/blog/20230829_schedule-for-td-agent-4-eol.md
+++ b/content/blog/20230829_schedule-for-td-agent-4-eol.md
@@ -26,7 +26,7 @@ There is a good article to do it.
 
 Follow the above instructions.
 
-TAG: Fluentd td-agent Announcement
+TAG: Fluentd td-agent Announcement reminder
 AUTHOR: clearcode
 
 

--- a/content/blog/tag/reminder
+++ b/content/blog/tag/reminder
@@ -1,0 +1,3 @@
+/blog/20230731_upgrade-td-agent-v4-to-v5
+/blog/20230829_fluent-package-scheduled-lifecycle
+/blog/20230829_schedule-for-td-agent-4-eol

--- a/views/blog.erb
+++ b/views/blog.erb
@@ -81,6 +81,15 @@
       -->
       <!-- End Search Bar -->
 
+      <!-- Topics -->
+      <div class="posts margin-bottom-20">
+        <div class="headline headline-md"><h2>Announcement Topics</h2></div>
+        <% @recent_reminder.each { |a| %>
+        <p><%= a[:date] %>: <a href="/blog/<%= a[:url] %>"><%= a[:title] %></a></p>
+        <% } %>
+      </div>
+      <!-- End Topics -->
+
       <!-- Posts -->
       <div class="posts margin-bottom-20">
         <div class="headline headline-md"><h2>Recent Posts</h2></div>

--- a/views/blog_single.erb
+++ b/views/blog_single.erb
@@ -77,6 +77,15 @@
       -->
       <!-- End Search Bar -->
 
+      <!-- Topics -->
+      <div class="posts margin-bottom-20">
+        <div class="headline headline-md"><h2>Announcement Topics</h2></div>
+        <% @recent_reminder.each { |a| %>
+        <p><%= a[:date] %>: <a href="/blog/<%= a[:url] %>"><%= a[:title] %></a></p>
+        <% } %>
+      </div>
+      <!-- End Topics -->
+
       <!-- Posts -->
       <div class="posts margin-bottom-20">
         <div class="headline headline-md"><h2>Recent Posts</h2></div>


### PR DESCRIPTION
When many release article was published, major
topics will not shown in "Recent Topics".
This commit introduces "Topics" category.