### PR TITLE
Update platform version for msi fluent-package

### DIFF
--- a/views/download_fluent_package.erb
+++ b/views/download_fluent_package.erb
@@ -133,7 +133,7 @@
                 Windows
               </center>
             </td>
-            <td>Windows Server 2012+ (64-bit)</td>
+            <td>Windows Server 2016+ (64-bit)<br/>Windows 10+ (64-bit)</td>
             <td>
               <span style="font-weight:bold">fluent-package LTS v<%=FLUENT_PACKAGE_VERSIONS[:v5_lts][:win]%></span>
               <ul>


### PR DESCRIPTION
Both desktop and server versions should be supported as long as the version is not out of Microsoft support.