### PR TITLE
blog: fix broken link and add related link

### DIFF
--- a/content/blog/20240329_fluent-package-v5.0.3-has-been-released.md
+++ b/content/blog/20240329_fluent-package-v5.0.3-has-been-released.md
@@ -11,7 +11,9 @@ As significant slow starting service and crash issues during startup on Windows 
 ### Changes from fluent-package v5.0.2
 
 * Update fluentd to [1.16.5](https://github.com/fluent/fluentd/releases/tag/v1.16.5).
-  See [Fluentd v1.16.5 has been released](/blog/fluentd-v1.16.5-has-been-released) blog article about details.
+  See the following blog articles about details.
+  * [Fluentd v1.16.4 has been released](fluentd-v1.16.4-have-been-released)
+  * [Fluentd v1.16.5 has been released](fluentd-v1.16.5-have-been-released)
 * Update bundled plugins
   * e.g. fluent-diagtool v1.0.5. It supports to collect list of plugins on Windows.
 * msi: fixed wrong environment path for Fluent Package Prompt ([#606](https://github.com/fluent/fluent-package-builder/pull/606))


### PR DESCRIPTION
https://www.fluentd.org/blog/fluent-package-v5.0.3-has-been-released

The following link is broken. (Originally, it was my file name issue. Sorry for this.)

> See [Fluentd v1.16.5 has been released](https://www.fluentd.org/blog/fluentd-v1.16.5-has-been-released) blog article about details.

This PR fixes it.
In addition, this PR adds v1.16.4 link.

after:

![Screenshot from 2024-04-08 14-45-44](https://github.com/fluent/fluentd-website/assets/12229857/fbe5e5d2-0434-421d-834e-bcf9002ad3c1)
