### PR TITLE
Fix Documentation's link is old

### DIFF
--- a/views/contributing.erb
+++ b/views/contributing.erb
@@ -46,7 +46,7 @@
       </p>
       <ul>
         <li><b>Fluentd</b>: Use <a href="https://github.com/fluent/fluentd">Fluentd</a> repository. Fill issue template.</li>
-        <li><b>Documentation</b>: Use <a href="https://github.com/fluent/fluentd-docs">Fluentd-Docs</a> repository.</li>
+        <li><b>Documentation</b>: Use <a href="https://github.com/fluent/fluentd-docs-gitbook">Fluentd-Docs</a> repository.</li>
       </ul>
       <p>
         If you find a bug of 3rd party plugins, please submit an issue to each plugin repository.


### PR DESCRIPTION
Fixed the link of this page.

https://www.fluentd.org/Contributing