### PR TITLE
Fix incorrect LTS version

### DIFF
--- a/views/download_fluent_package.erb
+++ b/views/download_fluent_package.erb
@@ -51,7 +51,7 @@
             </td>
             <td>2.6+ Linux kernel (64-bit)</td>
             <td>
-              <span style="font-weight:bold">fluent-package LTS v<%=FLUENT_PACKAGE_VERSIONS[:v5][:linux]%></span>
+              <span style="font-weight:bold">fluent-package LTS v<%=FLUENT_PACKAGE_VERSIONS[:v5_lts][:linux]%></span>
               <ul>
                 <li>
                   x86_64:


### PR DESCRIPTION
Since v5.1.0, normal release channel and LTS channel ships a different version of fluent-package, so I've noticed it.