### PR TITLE
blog: clarify td-agent v4 EOS explanation

### DIFF
--- a/content/blog/20230829_schedule-for-td-agent-4-eol.md
+++ b/content/blog/20230829_schedule-for-td-agent-4-eol.md
@@ -18,6 +18,10 @@ As you know, already stepping down maintenance activity, new minor update for td
 
 Thus, we recommend using fluent-package v5 for new deployment :)
 
+<div markdown="span" class="alert alert-danger" role="alert">
+<b>UPDATE:</b> Treasure Agent (td-agent) v4 was not supported anymore. The last td-agent release version are: v4.5.2 for Linux, v4.5.3 for Windows.
+</div>
+
 ## How to migrate to Fluent Package v5
 
 There is a good article to do it.

--- a/content/blog/20240329_fluent-package-v5.0.3-has-been-released.md
+++ b/content/blog/20240329_fluent-package-v5.0.3-has-been-released.md
@@ -35,12 +35,12 @@ As significant slow starting service and crash issues during startup on Windows 
 We plan to ship next LTS version of fluent-package v5.0.4 on June, 2024.
 The content of updates are still in T.B.D.
 
-### About td-agent v4.5.2 and v4.5.3 (Windows)
+### End of support for td-agent v4, let's migrate to fluent-package
 
 As it was already announced [Drop schedule announcement about EOL of Treasure Agent (td-agent) 4](schedule-for-td-agent-4-eol), td-agent v4 was reached EOL in Dec, 2023.
 
-There is a exceptional maintenance release for v4.5.3 on Windows because there was a crash bug during startup on Windows. It was backported fix from fluent-package v5 as
-it is critical in some case.
+After reached EOL, td-agent v4.5.3 on Windows was released because there was a crash bug during startup on Windows. It was backported fix from fluent-package v5 as
+it is critical in some case. Even though this was a exceptional maintenance release, but there is no change to the fact that we already stopped maintaining td-agent v4.
 
 We strongly recommend migrating from td-agent v4 to fluent-package v5 (LTS).
 See [Upgrade to fluent-package v5](upgrade-td-agent-v4-to-v5)

--- a/content/blog/20240702_fluent-package-v5.0.4-has-been-released.md
+++ b/content/blog/20240702_fluent-package-v5.0.4-has-been-released.md
@@ -80,12 +80,12 @@ On Linux:
 We plan to ship the next LTS version of fluent-package v5.0.5 on Oct, 2024.
 The content of updates are still in T.B.D.
 
-### About td-agent v4.5.2 and v4.5.3 (Windows)
+### End of support for td-agent v4, let's migrate to fluent-package
 
 As it was already announced [Drop schedule announcement about EOL of Treasure Agent (td-agent) 4](schedule-for-td-agent-4-eol), td-agent v4 was reached EOL in Dec, 2023.
 
-There is a exceptional maintenance release for v4.5.3 on Windows because there was a crash bug during startup on Windows. It was backported fix from fluent-package v5 as
-it is critical in some case.
+After reached EOL, td-agent v4.5.3 on Windows was released because there was a crash bug during startup on Windows. It was backported fix from fluent-package v5 as
+it is critical in some case. Even though this was a exceptional maintenance release, but there is no change to the fact that we already stopped maintaining td-agent v4.
 
 We strongly recommend migrating from td-agent v4 to fluent-package v5 (LTS).
 See [Upgrade to fluent-package v5](upgrade-td-agent-v4-to-v5)

--- a/content/blog/20240802_fluent-package-v5.1.0-has-been-released.md
+++ b/content/blog/20240802_fluent-package-v5.1.0-has-been-released.md
@@ -42,12 +42,12 @@ Please see [the download page](/download/fluent_package).
 We plan to ship the next LTS version of fluent-package v5.0.5 on Oct, 2024.
 The content of updates are still in T.B.D.
 
-#### About td-agent v4.5.2 and v4.5.3 (Windows)
+#### End of support for td-agent v4, let's migrate to fluent-package
 
 As it was already announced [Drop schedule announcement about EOL of Treasure Agent (td-agent) 4](schedule-for-td-agent-4-eol), td-agent v4 was reached EOL in Dec, 2023.
 
-There is a exceptional maintenance release for v4.5.3 on Windows because there was a crash bug during startup on Windows. It was backported fix from fluent-package v5 as
-it is critical in some case.
+After reached EOL, td-agent v4.5.3 on Windows was released because there was a crash bug during startup on Windows. It was backported fix from fluent-package v5 as
+it is critical in some case. Even though this was a exceptional maintenance release, but there is no change to the fact that we already stopped maintaining td-agent v4.
 
 We strongly recommend migrating from td-agent v4 to fluent-package v5 (LTS).
 See [Upgrade to fluent-package v5](upgrade-td-agent-v4-to-v5)


### PR DESCRIPTION
It is intended to emphasize "we stopped maintaining td-agent v4".
