### PR TITLE
update Fluent Bit Academy link

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -16,7 +16,7 @@
     <div class="row">
       <div class="col-md-12">
         <center>
-          <a href="https://calyptia.com/on-demand-webinars" target="_blank">
+          <a href="https://chronosphere.io/fluent-bit-academy/" target="_blank">
             <img src="/images/miscellany/fluent-bit-academy-banner.png" style="max-width: 35%;" alt="New Fluent Bit Academy!: Your destination for learning all things Fluent Bit" />
           </a>
         </center>


### PR DESCRIPTION
Fluent Bit Academy is now hosted by Chronsphere following the acquisition of Calyptia. Updating the link to its new home.