### PR TITLE
Bump version to LTS v5.0.5

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -57,13 +57,11 @@ TD_AGENT_VERSIONS = {
 FLUENT_PACKAGE_VERSIONS = {
   :v5 => {
     linux: "5.1.0",
-    mac: "5.1.0",
     win: "5.1.0"
   },
   :v5_lts => {
-    linux: "5.0.4",
-    mac: "5.0.4",
-    win: "5.0.4"
+    linux: "5.0.5",
+    win: "5.0.5"
   },
 }
 


### PR DESCRIPTION
NOTE: drop mac: entry because it is not shipped yet.