### PR TITLE
download-fluent-package: remove td-agent v3

### DIFF
--- a/views/download_fluent_package.erb
+++ b/views/download_fluent_package.erb
@@ -206,7 +206,7 @@
             </td>
             <td>2.6+ Linux kernel (64-bit)</td>
             <td>
-              <span style="font-weight:bold">td-agent v<%=TD_AGENT_VERSIONS[:v4][:linux]%></span>
+              <span style="font-weight:bold">td-agent v<%=TD_AGENT_VERSIONS[:v4][:linux]%> (old stable)</span>
               <ul>
                 <li>
                   x86_64:
@@ -223,13 +223,6 @@
                   <a href="https://td-agent-package-browser.herokuapp.com/4/amazon/2/aarch64">Amazon Linux 2</a>
                 </li>
               </ul>
-              <span style="font-weight:bold">td-agent v<%=TD_AGENT_VERSIONS[:v3][:linux]%> (old stable)</span>
-              <ul>
-                <li>
-                  <a href="https://td-agent-package-browser.herokuapp.com/3/redhat/7/x86_64">RHEL7</a>,
-                  <a href="https://td-agent-package-browser.herokuapp.com/3/redhat/6/x86_64">RHEL6</a>
-                </li>
-              </ul>
               <a href="https://docs.fluentd.org/v1.0/articles/install-by-rpm">Installation Guide</a><br>
             </td>
           </tr>
@@ -242,7 +235,7 @@
             </td>
             <td>2.6+ Linux kernel (64-bit)</td>
             <td>
-              <span style="font-weight:bold">td-agent v<%=TD_AGENT_VERSIONS[:v4][:linux]%></span>
+              <span style="font-weight:bold">td-agent v<%=TD_AGENT_VERSIONS[:v4][:linux]%> (old stable)</span>
               <ul>
                 <li>Ubuntu:
                   <a href="https://td-agent-package-browser.herokuapp.com/4/ubuntu/jammy/pool/contrib/t/td-agent">Jammy</a>,
@@ -253,19 +246,6 @@
                 <li>Debian:
                   <a href="https://td-agent-package-browser.herokuapp.com/4/debian/bullseye/pool/contrib/t/td-agent">Bullseye</a>,
                   <a href="https://td-agent-package-browser.herokuapp.com/4/debian/buster/pool/contrib/t/td-agent">Buster</a>
-                </li>
-              </ul>
-              <span style="font-weight:bold">td-agent v<%=TD_AGENT_VERSIONS[:v3][:linux]%> (old stable)</span>
-              <ul>
-                <li>Ubuntu:
-                  <a href="https://td-agent-package-browser.herokuapp.com/3/ubuntu/bionic/pool/contrib/t/td-agent">Bionic</a>,
-                  <a href="https://td-agent-package-browser.herokuapp.com/3/ubuntu/xenial/pool/contrib/t/td-agent">Xenial</a>,
-                  <a href="https://td-agent-package-browser.herokuapp.com/3/ubuntu/trusty/pool/contrib/t/td-agent">Trusty</a>
-                </li>
-                <li>Debian:
-                  <a href="https://td-agent-package-browser.herokuapp.com/3/debian/buster/pool/contrib/t/td-agent">Buster</a>
-                  <a href="https://td-agent-package-browser.herokuapp.com/3/debian/stretch/pool/contrib/t/td-agent">Stretch</a>,
-                  <a href="https://td-agent-package-browser.herokuapp.com/3/debian/jessie/pool/contrib/t/td-agent">Jessie</a>
                 </li>
               </ul>
               <a href="//docs.fluentd.org/v1.0/articles/install-by-deb">Installation Guide</a>
@@ -280,16 +260,10 @@
             </td>
             <td>Windows Server 2012+ (64-bit)</td>
             <td>
-              <span style="font-weight:bold">td-agent v<%=TD_AGENT_VERSIONS[:v4][:win]%></span>
+              <span style="font-weight:bold">td-agent v<%=TD_AGENT_VERSIONS[:v4][:win]%> (old stable)</span>
               <ul>
                 <li>
                   <a href="https://td-agent-package-browser.herokuapp.com/4/windows">msi repository</a>
-                </li>
-              </ul>
-              <span style="font-weight:bold">td-agent v<%=TD_AGENT_VERSIONS[:v3][:win]%> (old stable)</span>
-              <ul>
-                <li>
-                  <a href="https://td-agent-package-browser.herokuapp.com/3/windows">msi repository</a>
                 </li>
               </ul>
               <a href="//docs.fluentd.org/v1.0/articles/install-by-msi">Installation Guide</a>
@@ -304,16 +278,10 @@
             </td>
             <td>OSX 10.11 or later</td>
             <td>
-              <span style="font-weight:bold">td-agent v<%=TD_AGENT_VERSIONS[:v4][:mac]%></span>
+              <span style="font-weight:bold">td-agent v<%=TD_AGENT_VERSIONS[:v4][:mac]%> (old stable)</span>
               <ul>
                 <li>
                   <a href="https://td-agent-package-browser.herokuapp.com/4/macosx">dmg repository</a>
-                </li>
-              </ul>
-              <span style="font-weight:bold">td-agent v<%=TD_AGENT_VERSIONS[:v3][:mac]%> (old stable)</span>
-              <ul>
-                <li>
-                  <a href="https://td-agent-package-browser.herokuapp.com/3/macosx">dmg repository</a>
                 </li>
               </ul>
               <a href="//docs.fluentd.org/v1.0/articles/install-by-dmg">Installation Guide</a>


### PR DESCRIPTION
It would be enough to have v4 as the old stable.

https://www.fluentd.org/download/fluent_package

Before:

![Screenshot from 2025-01-21 10-25-51](https://github.com/user-attachments/assets/ea09a7dc-1172-49c4-b6be-0c247ced5299)

After:

![Screenshot from 2025-01-21 10-24-03](https://github.com/user-attachments/assets/b4814feb-f696-4ce9-92af-1d2a67bc426a)
