### PR TITLE
blog: fix tag

### DIFF
--- a/content/blog/20250314_fluentd-drop-alpine-docker-image.md
+++ b/content/blog/20250314_fluentd-drop-alpine-docker-image.md
@@ -42,5 +42,5 @@ For such a purpose, shorter v1.19 or v1.19.x tag will be available in the future
 
 Happy logging!
 
-TAG: Fluentd fluent-package Announcement
+TAG: Fluentd Docker Announcement
 AUTHOR: clearcode

--- a/content/blog/tag/docker
+++ b/content/blog/tag/docker
@@ -1,1 +1,2 @@
 /blog/20170209_Debian-based-fluentd-docker-image
+/blog/20250314_fluentd-drop-alpine-docker-image

--- a/content/blog/tag/fluent-package
+++ b/content/blog/tag/fluent-package
@@ -9,4 +9,3 @@
 /blog/20241108_fluent-package-v5.0.5-has-been-released
 /blog/20241214_fluent-package-v5.2.0-has-been-released
 /blog/20250214_fluent-package-v5.0.6-has-been-released
-/blog/20250314_fluentd-drop-alpine-docker-image


### PR DESCRIPTION
https://www.fluentd.org/blog/fluentd-drop-alpine-docker-image

The tags of this blog should not include `fluent-package`.
It should include `Docker` tag.