### PR TITLE
enterprise-services: add description

### DIFF
--- a/views/enterprise_services.erb
+++ b/views/enterprise_services.erb
@@ -52,6 +52,7 @@
             <p>
               クリアコードは、日本国内において航空会社、官公庁、通信事業者をはじめとした大規模ユーザーに対する支援を行ってきました。
               ご相談にはFluentd/Fluent Bitのコアメンテナが対応いたしますので、まずはお気軽にお問い合わせください。
+              また、XにてFluentdに関する情報を日本語で発信しています（<a href="https://x.com/fluentd_jp">@fluentd_jp</a>）。
             </p>
             <a class="btn btn-primary" role="button" href="https://www.clear-code.com/services/fluentd-service.html">Visit Website</a>
           </div>


### PR DESCRIPTION
https://www.fluentd.org/enterprise_services

Clearcode is posting information about Fluentd in Japanese on https://x.com/fluentd_jp.
