### PR TITLE
CI: Add workflow to check for any updates to the tag files overlooked

### DIFF
--- a/.github/workflows/check-tags.yaml
+++ b/.github/workflows/check-tags.yaml
@@ -1,0 +1,27 @@
+name: Check tag files
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  tags:
+    runs-on: ubuntu-latest
+
+    name: Check tag files
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.4
+          bundler-cache: true
+      - name: Check tag files are properly updated
+        run: |
+          bundle exec rake update_tags
+          git diff --quiet

--- a/.github/workflows/check-tags.yaml
+++ b/.github/workflows/check-tags.yaml
@@ -24,4 +24,4 @@ jobs:
       - name: Check tag files are properly updated
         run: |
           bundle exec rake update_tags
-          git diff --quiet
+          git --no-pager diff --exit-code


### PR DESCRIPTION
I often forget to update tags,
so this add a workflow to check for this.

This workflow run `bundle exec rake update_tags` on CI, 
and it will fail if there are any differences.

(You can see the results of the tests in https://github.com/Watson1978/fluentd-website/pull/1)