### PR TITLE
plugins: add source_code_uri field

### DIFF
--- a/scripts/plugins.rb
+++ b/scripts/plugins.rb
@@ -70,7 +70,8 @@ class Plugins
         authors: p["authors"],
         version: p["version"],
         downloads: p["downloads"],
-        homepage_uri: p["homepage_uri"]
+        homepage_uri: p["homepage_uri"],
+        source_code_uri: p["source_code_uri"],
       }
     }
 


### PR DESCRIPTION
Some fluent-plugins have different URI configuration between `homepage_uri` and `source_code_uri`.

So, I think it would be better `plugin.json` has `homepage_uri` and `source_code_uri` both.