### PR TITLE
scripts/plugins: Fix error

### DIFF
--- a/scripts/plugins.rb
+++ b/scripts/plugins.rb
@@ -88,7 +88,7 @@ class Plugins
       puts "added: #{added_plugins}"
       puts "deleted: #{deleted_plugins}"
     end
-    if force_update or need_update?
+    if force_update or need_update?(added_plugins, deleted_plugins)
       mark_obsolete(plugins)
       File.open(plugins_json, "w") do |file|
         file.write(JSON.pretty_generate(plugins))
@@ -97,7 +97,7 @@ class Plugins
     end
   end
 
-  def self.need_update?
+  def self.need_update?(added_plugins, deleted_plugins)
     added_plugins.size > 0 or deleted_plugins.size > 0 or has_been_a_week?
   end
 


### PR DESCRIPTION
Now `scripts/plugins` causes following error.

```
scripts/plugins.rb:101:in `need_update?': undefined local variable or method `added_plugins' for Plugins:Class (NameError)

    added_plugins.size > 0 or deleted_plugins.size > 0 or has_been_a_week?
    ^^^^^^^^^^^^^
	from scripts/plugins.rb:91:in `update'
	from scripts/plugins.rb:175:in `<main>'
Error: Process completed with exit code 1.
```

Ref. https://github.com/fluent/fluentd-website/actions/runs/16862475661

This PR will fix the error.
