### PR TITLE
Describe migration for v6.

### DIFF
--- a/views/download_fluent_package.erb
+++ b/views/download_fluent_package.erb
@@ -155,7 +155,18 @@
 
       <h4><a name=fluent-package></a>Fluent Package v5 (fluent-package)</h4>
 
-      <p>LTS for v5 will be supported until Dec, 2025. Please see <a href="/blog/fluent-package-v6-scheduled-lifecycle">Scheduled support lifecycle announcement about Fluent Package</a> for more details.</p>
+      <div class="alert alert-danger">
+        <p>
+          Fluent Package (fluent-package) v5 (LTS) had already reached <a href="/blog/schedule-for-fluent-package-5-eol">End of Life (EOL)</a> in Dec, 2025.
+        </p>
+        <p>
+          There is no support anymore - Thus No new release and No security update.
+        </p>
+        <p>
+          fluent-package user should migrate to Fluent Package v6.
+          See <a href="/blog/upgrade-guide-for-fluent-package-v6">Upgrade to fluent-package v6</a> for migration.
+        </p>
+      </div>
       <table class="table table-bordered">
         <thead>
           <tr>


### PR DESCRIPTION
When it had reached EOL about fluent-package v5, it should explain how to upgrade for v6.
