### PR TITLE
Hide navigation to newsletter

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -154,7 +154,7 @@
                 </a>
                 <ul class="dropdown-menu">
                   <li><a href="/blog/">Blog</a></li>
-                  <li><a href="/newsletter">News Letter</a></li>
+                  <!-- <li><a href="/newsletter">News Letter</a></li> -->
                   <li><a href="https://www.cognitoforms.com/Fluentecosystem/FluentEcosystemSurvey">Feedback</a></li>
                   <li><a href="https://store.cncf.io/collections/fluentd">Stickers / T-Shirts / Parkas</a></li>
 		              <li><a href="/contributing">Contributing</a></li>


### PR DESCRIPTION
For a long time, it seems that form is broken with Uncaught ReferenceError and Failed to load resource 404, so hide it until appropriately handled by admin.