### PR TITLE
circleci: fix missing bundle --path option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,8 @@ jobs:
       - checkout
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
       - run: echo -e "export RAILS_ENV=test\nexport RACK_ENV=test" >> $BASH_ENV
-      - run: 'bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3'
+      - run: 'bundle config set path vendor/bundle'
+      - run: 'bundle check || bundle install --jobs=4 --retry=3'
       #- run:
       #    command: bundle exec ruby -E UTF-8 scripts/test_5xx.rb
       #    environment:


### PR DESCRIPTION
Fix the following error:

  The `--path` flag has been removed because it relied on being remembered across
  bundler invocations, which bundler no longer does. Instead please use `bundle
  config set path 'vendor/bundle'`, and stop using this flag
  The `--path` flag has been removed because it relied on being remembered across
  bundler invocations, which bundler no longer does. Instead please use `bundle
  config set path 'vendor/bundle'`, and stop using this flag