### PR TITLE
circleci: reduce parallel jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
       - run: echo -e "export RAILS_ENV=test\nexport RACK_ENV=test" >> $BASH_ENV
       - run: 'bundle config set path vendor/bundle'
-      - run: 'bundle check || bundle install --jobs=4 --retry=3'
+      - run: 'bundle check || bundle install --jobs=2 --retry=3'
       #- run:
       #    command: bundle exec ruby -E UTF-8 scripts/test_5xx.rb
       #    environment:


### PR DESCRIPTION
Followup  #429 

It seems that parallel job consumes more memory and it causes OOM Killer when switching Ruby 3.2 to 3.4..