### PR TITLE
circleci: control parallel with MAKEFLAGS=

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
       - run: echo -e "export RAILS_ENV=test\nexport RACK_ENV=test" >> $BASH_ENV
       - run: 'bundle config set path vendor/bundle'
-      - run: 'bundle check || bundle install --jobs=2 --retry=3'
+      - run: 'bundle check || MAKEFLAGS=-j4 bundle install --retry=3'
       #- run:
       #    command: bundle exec ruby -E UTF-8 scripts/test_5xx.rb
       #    environment:


### PR DESCRIPTION
For rubygems 4.0.x, it might be better to
specify with MAKEFLAGS= for avoiding OOM killer by parallel build.