### PR TITLE
Fix a typo

### DIFF
--- a/views/blog_single.erb
+++ b/views/blog_single.erb
@@ -39,7 +39,7 @@
 
       <!-- Collect Fluentd Use-Case/Testimonials -->
       <div class="well well-sm">
-        There are some commercial supports for Fluentd, see <a href="/enterprise_service">Enterprise Services</a>. If you use Fluentd on production, Let's share your use-case/testimonial on <a href="/testimonials">Testimonials page</a>. Please consider to <a href="https://github.com/fluent/fluentd-website/issues/new?template=testimonials.yml">feedback Use-Case/Testimonials via GitHub</a>.
+        There are some commercial supports for Fluentd, see <a href="/enterprise_services">Enterprise Services</a>. If you use Fluentd on production, Let's share your use-case/testimonial on <a href="/testimonials">Testimonials page</a>. Please consider to <a href="https://github.com/fluent/fluentd-website/issues/new?template=testimonials.yml">feedback Use-Case/Testimonials via GitHub</a>.
       </div>
 
       <p>


### PR DESCRIPTION
It should be enterprise_services, not enterprise_service.

```
  get '/enterprise_services' do
    @title = "Enterprise Services"
    erb :enterprise_services
  end
```