### PR TITLE
Fix for custom domain on GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,13 +37,6 @@ jobs:
       # FIXME: Avoid broken scss asset pipeline, rewrite them!
       - name: Last resort patch
         run: |
-          sed -i "s|url('/fonts/|url('/fluentd-website/fonts/|g" build/stylesheets/font-awesome/font-awesome.css
-          sed -i  "s|url(/images/icons/|url(/fluentd-website/images/icons/|g" build/stylesheets/app.css
-          sed -i  "s|url(\"/images/|url(\"/fluentd-website/images/|g" build/stylesheets/app.css
-          sed -i  "s|url('/images/|url('/fluentd-website/images/|g" build/stylesheets/parallax-slider/parallax-slider.css
-          sed -i  "s|src=\"/images/|src=\"/fluentd-website/images/|g" build/javascripts/back-to-top.js
-          sed -i  "s|url(/images/|url(/fluentd-website/images/|g" build/stylesheets/style.css
-          sed -i  "s|url(/images/|url(/fluentd-website/images/|g" build/stylesheets/app.css
           # Change relative img path
           sed -i  "s|url(/assets/plugins/parallax-slider/img|img|g" build/stylesheets/parallax-slider/parallax-slider.css
       - name: Upload Pages artifact

--- a/config.rb
+++ b/config.rb
@@ -15,10 +15,10 @@ set :markdown,
 activate :directory_indexes
 
 # For *.github.io/fluentd-website
-set :http_prefix, '/fluentd-website/'
+#set :http_prefix, '/fluentd-website/'
 
 # For fluentd.org
-#set :http_prefix, '/'
+set :http_prefix, '/'
 
 helpers do
   def is_certified(plugin)


### PR DESCRIPTION
Followup #435  #436

In the previous version, set http_prefix to access
navigation links in https://fluent.github.io/fluentd-website.

When enabling custom domain on GitHub Pages, no need to
tweak http_prefix.

