### PR TITLE
netlify: add [[redirects]] configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,15 @@
 [build]
   command = "./scripts/build_netlify.sh"
   publish = "build"
+
+[[redirects]]
+  from = "https://discuss.fluentd.org/*"
+  to = "https://github.com/fluent/fluentd/discussions"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "https://slack.fluentd.org/*"
+  to = "https://launchpass.com/fluent-all"
+  status = 301
+  force = true


### PR DESCRIPTION
In Heroku era, LFIT manages DNS with dnsimple.com. They provides URL record feature, but it is not formalized way. For migrating to Netlify, Netlify DNS doesn't support URL record, so switch it as [[redirects]] in toml.

TODO: add discuss and slack in Netlify DNS.