### PR TITLE
ci: use minimum permissions:

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -5,6 +5,9 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     name: Add issue to project

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,8 +6,7 @@ on:
       - main
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: "pages"

--- a/.github/workflows/update-plugins.yaml
+++ b/.github/workflows/update-plugins.yaml
@@ -5,6 +5,9 @@ on:
     - cron: '8 14 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   update-plugins:
     runs-on: ubuntu-latest


### PR DESCRIPTION
deploy.yaml: no more use GitHub pages, so contents: read is enough
update-plugins.yaml: need explicitly write permission
add-to-project: using PAT, so contents: read is enough