### PR TITLE
ci: reduce update frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'


### PR DESCRIPTION
"Dependabot security updates" is enabled, so it is enough to apply normal updates in less frequency.