### PR TITLE
Update slack channel to CNCF's one

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,6 @@
 
 [[redirects]]
   from = "https://slack.fluentd.org/*"
-  to = "https://launchpass.com/fluent-all"
+  to = "https://slack.cncf.io"
   status = 301
   force = true

--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -47,7 +47,7 @@ title: Community
 
       <div class="clients-page margin-bottom-20">
         <img src="<%= config[:http_prefix] %>images/env_slack.png" alt="" />
-        <p><h3><a href="https://launchpass.com/fluent-all">Slack</a></h3>
+        <p><h3><a href="https://slack.cncf.io">Slack #fluentd</a></h3>
         Join our Slack channel!, register to get an invitation and stay in touch.
         </p>
       </div>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -97,7 +97,7 @@
             <a href="https://www.cognitoforms.com/Fluentecosystem/FluentEcosystemSurvey"><b>Feedback</b></a>
           </li>
           <li class="devider"></li>
-          <li class="socialbutton slack"><a href="https://launchpass.com/fluent-all"><img src="<%= config[:http_prefix] %>images/slack_badge.png" width="55px" alt="slack" /></a></li>
+          <li class="socialbutton slack"><a href="https://slack.cncf.io"><img src="<%= config[:http_prefix] %>images/slack_badge.png" width="55px" alt="slack" /></a></li>
           <li class="devider"></li>
           <li class="socialbutton github">
             <iframe title="github" src="https://ghbtns.com/github-btn.html?user=fluent&amp;repo=fluentd&amp;type=watch&amp;count=true" allowtransparency="true" scrolling="0" frameborder="0" height="25px" width="95px">


### PR DESCRIPTION
Apr 28, announced that fluent-all slack will be
shutting down next month.
Instead, recommended to moving CNCF's slack.

ref. https://www.cncf.io/membership-faq/#how-do-i-join-cncfs-slack