### PR TITLE
Drop fluentd collections on store.cncf.io

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -183,7 +183,6 @@
                   <li><a href="<%= config[:http_prefix] %>blog/">Blog</a></li>
                   <!-- <li><a href="<%= config[:http_prefix] %>newsletter">News Letter</a></li> -->
                   <li><a href="https://www.cognitoforms.com/Fluentecosystem/FluentEcosystemSurvey">Feedback</a></li>
-                  <li><a href="https://store.cncf.io/collections/fluentd">Stickers / T-Shirts / Parkas</a></li>
 		              <li><a href="<%= config[:http_prefix] %>contributing">Contributing</a></li>
                   <li><a href="<%= config[:http_prefix] %>community">Community List</a></li>
                   <li><a href="<%= config[:http_prefix] %>related-projects">Related Projects</a></li>


### PR DESCRIPTION
No more available.

Until Feb 2026, it was accessible. but not found anymore.

https://web.archive.org/web/20260203065658/https://store.cncf.io/collections/fluentd