### PR TITLE
Describe ClearCode's Fluentd enterprise services in English

### DIFF
--- a/source/enterprise_services.html.erb
+++ b/source/enterprise_services.html.erb
@@ -51,7 +51,12 @@ title: Enterprise Services
             </a>
           </div>
           <div class="col-sm-9">
-            <p>ClearCode is a core maintainer of Fluentd since 2014, based in Japan.</p>
+            <p>
+              ClearCode has been a core maintainer of Fluentd since 2014 and builds fluent-package, the official Fluentd distribution.
+              We provide commercial support in Japanese, and in English on request: support contracts with source-level troubleshooting, upgrades and td-agent EOL migration, security advisory response, performance tuning, custom plugin development, and Windows deployments.
+              Fixes go upstream, so customers never depend on private patches.
+              Fluent Bit is covered as well.
+            </p>
             <p>
               クリアコードは、日本国内において航空会社、官公庁、通信事業者をはじめとした大規模ユーザーに対する支援を行ってきました。
               ご相談にはFluentd/Fluent Bitのコアメンテナが対応いたしますので、まずはお気軽にお問い合わせください。

--- a/source/enterprise_services.html.erb
+++ b/source/enterprise_services.html.erb
@@ -54,7 +54,7 @@ title: Enterprise Services
             <p>
               ClearCode has been a core maintainer of Fluentd since 2014 and builds fluent-package, the official Fluentd distribution.
               We provide commercial support in Japanese, and in English on request: support contracts with source-level troubleshooting, upgrades and td-agent EOL migration, security advisory response, performance tuning, custom plugin development, and Windows deployments.
-              Fixes go upstream, so customers never depend on private patches.
+              Fixes go upstream, so customers can reap the benefits without the burden of maintaining private patches.
               Fluent Bit is covered as well.
             </p>
             <p>


### PR DESCRIPTION
The ClearCode entry on the Enterprise Services page only said that ClearCode is a core maintainer, and left the actual list of services in a Japanese-only paragraph.
People (and AI assistants) looking for commercial Fluentd support read this page in English.