### PR TITLE
Drop navigation to Google Groups

### DIFF
--- a/source/_right_menu.erb
+++ b/source/_right_menu.erb
@@ -15,7 +15,6 @@
   <p>Couldn't find enough information? Let's ask the community!</p>
   <ul class="list-unstyled">
     <li><i class="icon-ok color-green"></i><a rel="nofollow noopener noreferrer" target="_blank" href="https://github.com/fluent/fluentd/discussions">Forum</a></li>
-    <li><i class="icon-ok color-green"></i><a rel="nofollow noopener noreferrer" target="_blank" href="https://groups.google.com/forum/#!forum/fluentd">Google Group</a></li>
     <li><i class="icon-ok color-green"></i><a rel="nofollow noopener noreferrer" target="_blank" href="<%= config[:http_prefix] %>newsletter">News Letter</a></li>
     <li><i class="icon-stackexchange color-green"></i><a rel="nofollow noopener noreferrer" target="_blank" href="https://stackoverflow.com/questions/tagged/fluentd">Stack Overflow</a></li>
     <li><i class="icon-github-alt color-green"></i><a rel="nofollow noopener noreferrer" target="_blank" href="https://github.com/fluent/fluentd/issues">Issue Tracker</a></li>

--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -20,14 +20,7 @@ title: Community
       <div class="clients-page margin-bottom-20">
         <img src="<%= config[:http_prefix] %>images/env_icon.png" alt="" />
         <p><h3><a href="https://github.com/fluent/fluentd/discussions">Forum</a></h3>
-          Got a question? Have some cool Fluentd-related projects? The forum is the place to be.
-        </p>
-      </div>
-
-      <div class="clients-page margin-bottom-20">
-        <img src="<%= config[:http_prefix] %>images/env_icon.png" alt="" />
-        <p><h3><a href="https://groups.google.com/forum/#!forum/fluentd">Mailing List</a></h3>
-          We are migrating to the new <a href="https://github.com/fluent/fluentd/discussions">Forum</a> above, so please don't post new articles here.
+          Got a question? Have some cool Fluentd-related projects? The forum (GitHub Discussions) is the place to be.
         </p>
       </div>
 
@@ -49,6 +42,12 @@ title: Community
         <img src="<%= config[:http_prefix] %>images/env_slack.png" alt="" />
         <p><h3><a href="https://slack.cncf.io">Slack #fluentd</a></h3>
         Join our Slack channel!, register to get an invitation and stay in touch.
+        </p>
+      </div>
+
+      <div class="clients-page margin-bottom-20">
+        <p>At the past, <a href="https://groups.google.com/forum/#!forum/fluentd">Mailing List</a> was used, but
+          We migrated it to <a href="https://github.com/fluent/fluentd/discussions">GitHub Discussions</a> above, so please don't post new articles here.
         </p>
       </div>
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -250,7 +250,6 @@
               <div class="headline"><h2>Community</h2></div>
               <ul class="list-unstyled">
                 <li><i class="icon-ok color-green"></i><a rel="nofollow noopener noreferrer" target="_blank" href="https://github.com/fluent/fluentd/discussions">Forum</a></li>
-                <li><i class="icon-ok color-green"></i><a rel="nofollow noopener noreferrer" target="_blank" href="https://groups.google.com/forum/#!forum/fluentd">Google Group</a></li>
                 <li><i class="icon-stackexchange color-green"></i><a rel="nofollow noopener noreferrer" target="_blank" href="https://stackoverflow.com/questions/tagged/fluentd">Stack Overflow</a></li>
                 <li><i class="icon-github-alt color-green"></i><a rel="nofollow noopener noreferrer" target="_blank" href="https://github.com/fluent/fluentd/issues">Issue Tracker</a></li>
                 <li><i class="icon-twitter color-green"></i><a rel="nofollow noopener noreferrer" target="_blank" href="https://twitter.com/fluentd">Twitter</a></li>


### PR DESCRIPTION
As a historical reasons, keep it on only community page.